### PR TITLE
fix: resolve make docker-up OIDC issuer mismatch and wrong client ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
   proto-lint:
     name: Proto Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # required for buf-action to post lint/breaking summaries as PR comments
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,11 @@ This certifies that you wrote the patch or have the right to submit it. See [dev
 git clone https://github.com/jitsudo-dev/jitsudo
 cd jitsudo
 
-# Start the local development environment
+# Start dependencies (postgres + dex) in Docker, run jitsudod on the host
+make dev-deps   # start postgres + dex
+make dev-server # build and run jitsudod locally (faster iteration)
+
+# Alternatively, start the full stack in Docker
 make docker-up
 
 # Build both binaries

--- a/api/proto/jitsudo/v1alpha1/principals.proto
+++ b/api/proto/jitsudo/v1alpha1/principals.proto
@@ -31,7 +31,7 @@ message Principal {
 // SetPrincipalTrustTierInput is the request body for admin tier assignment.
 message SetPrincipalTrustTierInput {
   string identity = 1;
-  int32  trust_tier = 2;
+  int32 trust_tier = 2;
   string notes = 3;
 }
 

--- a/api/proto/jitsudo/v1alpha1/service.proto
+++ b/api/proto/jitsudo/v1alpha1/service.proto
@@ -26,16 +26,12 @@ service JitsudoService {
 
   // ListRequests returns a filtered list of elevation requests.
   rpc ListRequests(ListRequestsFilter) returns (ListRequestsResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/requests"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/requests"};
   }
 
   // GetRequest returns a single elevation request by ID.
   rpc GetRequest(GetRequestInput) returns (GetRequestResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/requests/{id}"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/requests/{id}"};
   }
 
   // ApproveRequest approves a pending elevation request.
@@ -64,25 +60,19 @@ service JitsudoService {
 
   // GetCredentials retrieves the active credentials for an approved/active request.
   rpc GetCredentials(GetCredentialsInput) returns (GetCredentialsResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/requests/{request_id}/credentials"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/requests/{request_id}/credentials"};
   }
 
   // --- Policies ---
 
   // ListPolicies returns all stored Rego policies.
   rpc ListPolicies(ListPoliciesInput) returns (ListPoliciesResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/policies"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/policies"};
   }
 
   // GetPolicy returns a single policy by ID.
   rpc GetPolicy(GetPolicyInput) returns (GetPolicyResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/policies/{id}"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/policies/{id}"};
   }
 
   // ApplyPolicy creates or updates a policy (upsert by name).
@@ -95,9 +85,7 @@ service JitsudoService {
 
   // DeletePolicy removes a policy by ID.
   rpc DeletePolicy(DeletePolicyInput) returns (DeletePolicyResponse) {
-    option (google.api.http) = {
-      delete: "/api/v1alpha1/policies/{id}"
-    };
+    option (google.api.http) = {delete: "/api/v1alpha1/policies/{id}"};
   }
 
   // EvalPolicy performs a dry-run evaluation of the current policy set.
@@ -112,9 +100,7 @@ service JitsudoService {
 
   // QueryAudit queries the append-only audit log with optional filters.
   rpc QueryAudit(QueryAuditInput) returns (QueryAuditResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/audit"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/audit"};
   }
 
   // --- Admin ---
@@ -141,9 +127,7 @@ service JitsudoService {
 
   // GetPrincipal returns the enrollment record for a principal.
   rpc GetPrincipal(GetPrincipalInput) returns (GetPrincipalResponse) {
-    option (google.api.http) = {
-      get: "/api/v1alpha1/principals/{identity}"
-    };
+    option (google.api.http) = {get: "/api/v1alpha1/principals/{identity}"};
   }
 }
 

--- a/cmd/jitsudod/serve.go
+++ b/cmd/jitsudod/serve.go
@@ -43,11 +43,12 @@ func runServe(ctx context.Context, configPath string) error {
 	defer st.Close()
 
 	srv := server.New(server.Config{
-		HTTPAddr:     cfg.Server.HTTPAddr,
-		GRPCAddr:     cfg.Server.GRPCAddr,
-		DatabaseURL:  cfg.Database.URL,
-		OIDCIssuer:   cfg.Auth.OIDCIssuer,
-		OIDCClientID: cfg.Auth.ClientID,
+		HTTPAddr:         cfg.Server.HTTPAddr,
+		GRPCAddr:         cfg.Server.GRPCAddr,
+		DatabaseURL:      cfg.Database.URL,
+		OIDCIssuer:       cfg.Auth.OIDCIssuer,
+		OIDCDiscoveryURL: cfg.Auth.OIDCDiscoveryURL,
+		OIDCClientID:     cfg.Auth.ClientID,
 		TLS: server.TLSConfig{
 			CertFile: cfg.TLS.CertFile,
 			KeyFile:  cfg.TLS.KeyFile,

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -53,8 +53,9 @@ services:
       JITSUDOD_HTTP_ADDR: ":8080"
       JITSUDOD_GRPC_ADDR: ":8443"
       JITSUDOD_DATABASE_URL: "postgres://jitsudo:jitsudo@postgres:5432/jitsudo?sslmode=disable"
-      JITSUDOD_OIDC_ISSUER: "http://dex:5556/dex"
-      JITSUDOD_OIDC_CLIENT_ID: "jitsudo-server"
+      JITSUDOD_OIDC_ISSUER: "http://localhost:5556/dex"
+      JITSUDOD_OIDC_DISCOVERY_URL: "http://dex:5556/dex"
+      JITSUDOD_OIDC_CLIENT_ID: "jitsudo-cli"
     ports:
       - "8080:8080"
       - "8443:8443"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,8 +57,9 @@ type DatabaseCfg struct {
 
 // AuthCfg holds OIDC settings for verifying inbound JWTs.
 type AuthCfg struct {
-	OIDCIssuer string `yaml:"oidc_issuer"`
-	ClientID   string `yaml:"client_id"`
+	OIDCIssuer       string `yaml:"oidc_issuer"`
+	OIDCDiscoveryURL string `yaml:"oidc_discovery_url"`
+	ClientID         string `yaml:"client_id"`
 }
 
 // TLSCfg holds paths to TLS credentials for the gRPC listener.
@@ -147,6 +148,7 @@ func applyEnv(cfg *FileConfig) {
 	setIfEnv(&cfg.Server.GRPCAddr, "JITSUDOD_GRPC_ADDR")
 	setIfEnv(&cfg.Database.URL, "JITSUDOD_DATABASE_URL")
 	setIfEnv(&cfg.Auth.OIDCIssuer, "JITSUDOD_OIDC_ISSUER")
+	setIfEnv(&cfg.Auth.OIDCDiscoveryURL, "JITSUDOD_OIDC_DISCOVERY_URL")
 	setIfEnv(&cfg.Auth.ClientID, "JITSUDOD_OIDC_CLIENT_ID")
 	setIfEnv(&cfg.TLS.CertFile, "JITSUDOD_TLS_CERT_FILE")
 	setIfEnv(&cfg.TLS.KeyFile, "JITSUDOD_TLS_KEY_FILE")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,7 +33,7 @@ func TestLoad_YAMLOverridesDefaults(t *testing.T) {
 	for _, key := range []string{
 		"JITSUDOD_HTTP_ADDR", "JITSUDOD_GRPC_ADDR",
 		"JITSUDOD_DATABASE_URL",
-		"JITSUDOD_OIDC_ISSUER", "JITSUDOD_OIDC_CLIENT_ID",
+		"JITSUDOD_OIDC_ISSUER", "JITSUDOD_OIDC_DISCOVERY_URL", "JITSUDOD_OIDC_CLIENT_ID",
 		"JITSUDOD_TLS_CERT_FILE", "JITSUDOD_TLS_KEY_FILE", "JITSUDOD_TLS_CA_FILE",
 		"JITSUDOD_LOG_LEVEL",
 		"JITSUDOD_SLACK_WEBHOOK_URL", "JITSUDOD_SMTP_HOST", "JITSUDOD_SMTP_PASSWORD",
@@ -164,6 +164,65 @@ func TestLoad_MissingFile(t *testing.T) {
 	_, err := config.Load("/nonexistent/path/config.yaml")
 	if err == nil {
 		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestLoad_OIDCDiscoveryURL_YAML(t *testing.T) {
+	t.Setenv("JITSUDOD_OIDC_DISCOVERY_URL", "") // ensure env doesn't interfere
+	yaml := `
+auth:
+  oidc_issuer: "http://localhost:5556/dex"
+  oidc_discovery_url: "http://dex:5556/dex"
+  client_id: "jitsudo-cli"
+`
+	path := writeTemp(t, yaml)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Auth.OIDCDiscoveryURL != "http://dex:5556/dex" {
+		t.Errorf("Auth.OIDCDiscoveryURL = %q, want http://dex:5556/dex", cfg.Auth.OIDCDiscoveryURL)
+	}
+	if cfg.Auth.OIDCIssuer != "http://localhost:5556/dex" {
+		t.Errorf("Auth.OIDCIssuer = %q, want http://localhost:5556/dex", cfg.Auth.OIDCIssuer)
+	}
+}
+
+func TestLoad_OIDCDiscoveryURL_EnvVar(t *testing.T) {
+	t.Setenv("JITSUDOD_OIDC_DISCOVERY_URL", "http://dex:5556/dex")
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Auth.OIDCDiscoveryURL != "http://dex:5556/dex" {
+		t.Errorf("Auth.OIDCDiscoveryURL = %q, want http://dex:5556/dex", cfg.Auth.OIDCDiscoveryURL)
+	}
+}
+
+func TestLoad_OIDCDiscoveryURL_EnvOverridesYAML(t *testing.T) {
+	yaml := `
+auth:
+  oidc_discovery_url: "http://from-yaml:5556/dex"
+`
+	path := writeTemp(t, yaml)
+	t.Setenv("JITSUDOD_OIDC_DISCOVERY_URL", "http://from-env:5556/dex")
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Auth.OIDCDiscoveryURL != "http://from-env:5556/dex" {
+		t.Errorf("Auth.OIDCDiscoveryURL = %q, want http://from-env:5556/dex", cfg.Auth.OIDCDiscoveryURL)
+	}
+}
+
+func TestLoad_OIDCDiscoveryURL_DefaultEmpty(t *testing.T) {
+	t.Setenv("JITSUDOD_OIDC_DISCOVERY_URL", "")
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Auth.OIDCDiscoveryURL != "" {
+		t.Errorf("Auth.OIDCDiscoveryURL default = %q, want empty string", cfg.Auth.OIDCDiscoveryURL)
 	}
 }
 

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -20,8 +20,9 @@ import (
 
 // Config holds OIDC verifier configuration.
 type Config struct {
-	Issuer   string // OIDC issuer URL, e.g. "http://localhost:5556/dex"
-	ClientID string // Expected audience claim, e.g. "jitsudo-cli"
+	Issuer       string // OIDC issuer URL, e.g. "http://localhost:5556/dex"
+	DiscoveryURL string // Optional: override the OIDC discovery endpoint (e.g. Docker-internal URL). Defaults to Issuer when empty.
+	ClientID     string // Expected audience claim, e.g. "jitsudo-cli"
 }
 
 // Identity holds the verified claims extracted from an OIDC ID token.
@@ -37,10 +38,24 @@ type Verifier struct {
 }
 
 // NewVerifier constructs a Verifier by fetching the OIDC discovery document.
+// When cfg.DiscoveryURL is set, the discovery document is fetched from that URL
+// but tokens are expected to carry cfg.Issuer as their "iss" claim. This supports
+// deployments where the OIDC provider is reachable only via an internal address
+// (e.g. Docker service name) while tokens use a public or host-facing issuer URL.
+//
+// Security note: cfg.DiscoveryURL MUST point to the same OIDC provider as cfg.Issuer.
+// Setting it to a different provider's endpoint would allow that provider's keys to be
+// used for verification, which is a security vulnerability. This option exists only to
+// decouple the network-level connection endpoint from the issuer URL in tokens.
 func NewVerifier(ctx context.Context, cfg Config) (*Verifier, error) {
-	provider, err := gooidc.NewProvider(ctx, cfg.Issuer)
+	discoveryURL := cfg.Issuer
+	if cfg.DiscoveryURL != "" {
+		discoveryURL = cfg.DiscoveryURL
+		ctx = gooidc.InsecureIssuerURLContext(ctx, cfg.Issuer)
+	}
+	provider, err := gooidc.NewProvider(ctx, discoveryURL)
 	if err != nil {
-		return nil, fmt.Errorf("auth: OIDC discovery for %q: %w", cfg.Issuer, err)
+		return nil, fmt.Errorf("auth: OIDC discovery for %q: %w", discoveryURL, err)
 	}
 	v := provider.Verifier(&gooidc.Config{ClientID: cfg.ClientID})
 	return &Verifier{verifier: v}, nil

--- a/internal/server/auth/auth_test.go
+++ b/internal/server/auth/auth_test.go
@@ -1,0 +1,118 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
+)
+
+// startFakeOIDC starts an httptest.Server acting as a minimal OIDC provider.
+// The discovery document advertises issuerURL as the issuer. The JWKS endpoint
+// returns an empty key set (sufficient for NewVerifier, which only fetches keys
+// at startup and does not verify tokens here).
+func startFakeOIDC(t *testing.T, issuerURL string) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   issuerURL,
+			"jwks_uri": srv.URL + "/keys",
+		})
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{}})
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewVerifier_NormalPath verifies that NewVerifier succeeds when Issuer
+// and the discovery endpoint are the same URL (the common production case).
+func TestNewVerifier_NormalPath(t *testing.T) {
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// issuer in the discovery doc matches the URL we connect to.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   srv.URL,
+			"jwks_uri": srv.URL + "/keys",
+		})
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{}})
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	_, err := auth.NewVerifier(context.Background(), auth.Config{
+		Issuer:   srv.URL,
+		ClientID: "test-client",
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier (no DiscoveryURL): %v", err)
+	}
+}
+
+// TestNewVerifier_IssueMismatch_Fails verifies that NewVerifier fails when
+// the discovery document's issuer does not match the connection URL and no
+// DiscoveryURL override is provided. This is the standard go-oidc safety check.
+func TestNewVerifier_IssueMismatch_Fails(t *testing.T) {
+	srv := startFakeOIDC(t, "http://other.example.com") // issuer ≠ srv.URL
+
+	_, err := auth.NewVerifier(context.Background(), auth.Config{
+		Issuer:   srv.URL,
+		ClientID: "test-client",
+	})
+	if err == nil {
+		t.Fatal("expected error for issuer mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not match") {
+		t.Errorf("error %q does not mention issuer mismatch", err)
+	}
+}
+
+// TestNewVerifier_WithDiscoveryURL verifies the Docker-internal-endpoint use case:
+// the discovery document is fetched from DiscoveryURL (e.g. "http://dex:5556/dex")
+// but the issuer in tokens is expected to be Issuer (e.g. "http://localhost:5556/dex").
+// The server returns the public Issuer URL in its discovery doc.
+func TestNewVerifier_WithDiscoveryURL(t *testing.T) {
+	const publicIssuer = "http://localhost:5556/dex"
+
+	srv := startFakeOIDC(t, publicIssuer) // discovery URL is srv.URL, but issuer = publicIssuer
+
+	_, err := auth.NewVerifier(context.Background(), auth.Config{
+		Issuer:       publicIssuer,
+		DiscoveryURL: srv.URL, // connect here for discovery...
+		ClientID:     "jitsudo-cli",
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier with DiscoveryURL: %v", err)
+	}
+}
+
+// TestNewVerifier_DiscoveryURLUnreachable verifies that a connection error on
+// DiscoveryURL (not Issuer) surfaces correctly when the override is used.
+func TestNewVerifier_DiscoveryURLUnreachable(t *testing.T) {
+	_, err := auth.NewVerifier(context.Background(), auth.Config{
+		Issuer:       "http://localhost:5556/dex",
+		DiscoveryURL: "http://127.0.0.1:19999", // nothing listening here
+		ClientID:     "jitsudo-cli",
+	})
+	if err == nil {
+		t.Fatal("expected error for unreachable DiscoveryURL, got nil")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,11 +41,12 @@ import (
 
 // Config holds the server configuration.
 type Config struct {
-	HTTPAddr     string // e.g., ":8080"
-	GRPCAddr     string // e.g., ":8443"
-	DatabaseURL  string // PostgreSQL DSN
-	OIDCIssuer   string // e.g., "http://localhost:5556/dex"
-	OIDCClientID string // e.g., "jitsudo-cli"
+	HTTPAddr         string // e.g., ":8080"
+	GRPCAddr         string // e.g., ":8443"
+	DatabaseURL      string // PostgreSQL DSN
+	OIDCIssuer       string // e.g., "http://localhost:5556/dex"
+	OIDCDiscoveryURL string // optional: Docker-internal OIDC endpoint (overrides connection target, not expected issuer)
+	OIDCClientID     string // e.g., "jitsudo-cli"
 
 	// TLS configures mTLS for the gRPC listener.
 	// Leave zero-value for insecure local development.
@@ -117,8 +118,9 @@ func New(cfg Config, s *store.Store) *Server {
 func (s *Server) Start(ctx context.Context) error {
 	// ── Auth middleware ───────────────────────────────────────────────────────
 	verifier, err := auth.NewVerifier(ctx, auth.Config{
-		Issuer:   s.cfg.OIDCIssuer,
-		ClientID: s.cfg.OIDCClientID,
+		Issuer:       s.cfg.OIDCIssuer,
+		DiscoveryURL: s.cfg.OIDCDiscoveryURL,
+		ClientID:     s.cfg.OIDCClientID,
 	})
 	if err != nil {
 		return fmt.Errorf("server: auth verifier: %w", err)


### PR DESCRIPTION
## Summary

- Adds `JITSUDOD_OIDC_DISCOVERY_URL` config option so jitsudod can connect to dex via the Docker-internal service name (`http://dex:5556/dex`) while expecting `http://localhost:5556/dex` as the `iss` claim in tokens — matching `dex-config.yaml` and the CLI
- Fixes `JITSUDOD_OIDC_CLIENT_ID` in `deploy/docker-compose.yaml` from `jitsudo-server` to `jitsudo-cli` to match the `aud` claim in CLI-issued tokens
- Adds unit tests for `auth.NewVerifier` (normal path, issuer mismatch, `DiscoveryURL` override, unreachable `DiscoveryURL`) and for the new `OIDCDiscoveryURL` config field

## Background

`make docker-up` was broken: jitsudod exited immediately because `go-oidc/v3` enforces that the OIDC discovery URL and the `iss` field in the discovery document match exactly. `dex-config.yaml` advertises `http://localhost:5556/dex` but `JITSUDOD_OIDC_ISSUER` was set to `http://dex:5556/dex` (the Docker-internal name). The `JITSUDOD_OIDC_CLIENT_ID` bug would have caused runtime token rejection even after fixing the first issue.

`JITSUDOD_OIDC_DISCOVERY_URL` uses `go-oidc/v3`'s `InsecureIssuerURLContext` — the library's supported API for the private-endpoint/public-issuer pattern. JWT signature verification and all claim checks (`iss`, `aud`, `exp`) are unchanged. The option is disabled when empty (the default).

## Test plan

- [ ] `make docker-down && make docker-up` — all three containers stay up in `docker ps`
- [ ] `docker logs deploy-jitsudod-1` — shows gRPC and HTTP listeners starting, no fatal errors
- [ ] `go test ./internal/config/... ./internal/server/auth/...` — all 18 tests pass
- [ ] `make dev-deps && make dev-server` — host-based workflow unaffected

Closes #1