### PR TITLE
fix: correct awk patterns for checksum extraction in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,10 @@ jobs:
             -o checksums.txt
 
           # sha256sum format: "<hash>  <filename>"
-          export DARWIN_AMD64=$(awk '/jitsudo-darwin-amd64[[:space:]]/{print $1}' checksums.txt)
-          export DARWIN_ARM64=$(awk '/jitsudo-darwin-arm64[[:space:]]/{print $1}' checksums.txt)
-          export LINUX_AMD64=$(awk '/jitsudo-linux-amd64[[:space:]]/{print $1}' checksums.txt)
-          export LINUX_ARM64=$(awk '/jitsudo-linux-arm64[[:space:]]/{print $1}' checksums.txt)
+          export DARWIN_AMD64=$(awk '$NF == "jitsudo-darwin-amd64" {print $1}' checksums.txt)
+          export DARWIN_ARM64=$(awk '$NF == "jitsudo-darwin-arm64" {print $1}' checksums.txt)
+          export LINUX_AMD64=$(awk '$NF == "jitsudo-linux-amd64" {print $1}' checksums.txt)
+          export LINUX_ARM64=$(awk '$NF == "jitsudo-linux-arm64" {print $1}' checksums.txt)
           export VERSION_NUM="${VERSION#v}"
 
           git clone \


### PR DESCRIPTION
## Summary

The `homebrew-tap` job extracts SHA256 checksums from `checksums.txt` using awk patterns like:

```sh
export DARWIN_AMD64=$(awk '/jitsudo-darwin-amd64[[:space:]]/{print $1}' checksums.txt)
```

**These patterns never match.** The `sha256sum` output format is `<hash>  <filename>`, with the filename at the **end** of the line — no trailing whitespace. The pattern `/filename[[:space:]]/` requires a space *after* the filename, which doesn't exist.

**Proof the bug is real:**
```sh
printf 'abc123  jitsudo-darwin-amd64\n' | awk '/jitsudo-darwin-amd64[[:space:]]/{print $1}'
# → (no output)
```

As a result, all four checksum variables are always empty strings. Every release pushes a Homebrew formula with `sha256 ""` for every platform, causing `brew install jitsudo-dev/tap/jitsudo` to fail with a checksum error.

## Fix

Replace the regex patterns with `$NF == "filename"` (exact match on the last field):

```sh
export DARWIN_AMD64=$(awk '$NF == "jitsudo-darwin-amd64" {print $1}' checksums.txt)
export DARWIN_ARM64=$(awk '$NF == "jitsudo-darwin-arm64" {print $1}' checksums.txt)
export LINUX_AMD64=$(awk '$NF == "jitsudo-linux-amd64" {print $1}' checksums.txt)
export LINUX_ARM64=$(awk '$NF == "jitsudo-linux-arm64" {print $1}' checksums.txt)
```

**Proof the fix works:**
```sh
printf 'abc123  jitsudo-darwin-amd64\n' | awk '$NF == "jitsudo-darwin-amd64" {print $1}'
# → abc123
```

`$NF` is the last field, correctly matching regardless of whitespace format. Works on GNU awk, mawk, and BSD awk.

Closes #4