### PR TITLE
fix(cli): add JITSUDO_SERVER env var support, actionable errors, and relaxed request flags

### DIFF
--- a/internal/cli/request.go
+++ b/internal/cli/request.go
@@ -79,16 +79,14 @@ Upon approval, credentials are issued for the specified duration and automatical
 	cmd.Flags().StringVar(&provider, "provider", "", "Cloud provider: aws, azure, gcp, kubernetes (required)")
 	cmd.Flags().StringVar(&role, "role", "", "Role or permission set to request (required)")
 	cmd.Flags().StringVar(&scope, "scope", "", "Resource scope: AWS account ID, GCP project, K8s namespace (required)")
-	cmd.Flags().StringVar(&duration, "duration", "", "Elevation duration, e.g. 1h, 30m (required)")
-	cmd.Flags().StringVar(&reason, "reason", "", "Justification for the request (required)")
+	cmd.Flags().StringVar(&duration, "duration", "1h", "Elevation duration, e.g. 1h, 30m (default: 1h)")
+	cmd.Flags().StringVar(&reason, "reason", "", "Justification for the request")
 	cmd.Flags().BoolVar(&breakGlass, "break-glass", false, "Emergency break-glass mode: bypass approval with immediate alerts")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Block until the request is approved or denied")
 
 	_ = cmd.MarkFlagRequired("provider")
 	_ = cmd.MarkFlagRequired("role")
 	_ = cmd.MarkFlagRequired("scope")
-	_ = cmd.MarkFlagRequired("duration")
-	_ = cmd.MarkFlagRequired("reason")
 
 	return cmd
 }

--- a/internal/cli/request_test.go
+++ b/internal/cli/request_test.go
@@ -1,0 +1,59 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRequestCmd_DurationDefault(t *testing.T) {
+	cmd := newRequestCmd()
+	f := cmd.Flags().Lookup("duration")
+	if f == nil {
+		t.Fatal("--duration flag not defined")
+	}
+	if f.DefValue != "1h" {
+		t.Errorf("default --duration = %q, want %q", f.DefValue, "1h")
+	}
+}
+
+func TestRequestCmd_DurationNotRequired(t *testing.T) {
+	cmd := newRequestCmd()
+	f := cmd.Flags().Lookup("duration")
+	if f == nil {
+		t.Fatal("--duration flag not defined")
+	}
+	_, isRequired := f.Annotations[cobra.BashCompOneRequiredFlag]
+	if isRequired {
+		t.Error("--duration should not be marked required (it has a default of 1h)")
+	}
+}
+
+func TestRequestCmd_ReasonNotRequired(t *testing.T) {
+	cmd := newRequestCmd()
+	f := cmd.Flags().Lookup("reason")
+	if f == nil {
+		t.Fatal("--reason flag not defined")
+	}
+	_, isRequired := f.Annotations[cobra.BashCompOneRequiredFlag]
+	if isRequired {
+		t.Error("--reason should not be marked required (enforcement belongs in OPA policy)")
+	}
+}
+
+func TestRequestCmd_CoreFlagsStillRequired(t *testing.T) {
+	cmd := newRequestCmd()
+	for _, name := range []string{"provider", "role", "scope"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			t.Fatalf("--%s flag not defined", name)
+		}
+		_, isRequired := f.Annotations[cobra.BashCompOneRequiredFlag]
+		if !isRequired {
+			t.Errorf("--%s should be marked required", name)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -75,6 +75,14 @@ Documentation: https://jitsudo.dev/docs`,
 // with any command-line flag overrides.
 func newClient(ctx context.Context) (*client.Client, error) {
 	serverURL := flags.serverURL
+
+	// Fall back to JITSUDO_SERVER env var or config file key "server".
+	// initConfig already called viper.SetEnvPrefix("JITSUDO") + AutomaticEnv(),
+	// so viper.GetString("server") automatically reads JITSUDO_SERVER.
+	if serverURL == "" {
+		serverURL = viper.GetString("server")
+	}
+
 	token := flags.token
 
 	// Fall back to stored credentials for any unset values.
@@ -89,6 +97,10 @@ func newClient(ctx context.Context) (*client.Client, error) {
 		if token == "" {
 			token = creds.Token
 		}
+	}
+
+	if serverURL == "" {
+		return nil, fmt.Errorf("no server URL configured — pass --server <URL>, set JITSUDO_SERVER=<URL>, or add 'server: <URL>' to ~/.jitsudo/config.yaml")
 	}
 
 	cfg := client.Config{

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// setupViperForTest resets viper to a clean state and initialises the env
+// prefix so that JITSUDO_* variables are picked up.  It returns a cleanup
+// function that the caller should defer.
+func setupViperForTest(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+	viper.SetEnvPrefix("JITSUDO")
+	viper.AutomaticEnv()
+	t.Cleanup(viper.Reset)
+}
+
+// writeCredentials writes a minimal credentials YAML to tmp/.jitsudo/credentials
+// and sets HOME=tmp so os.UserHomeDir() returns tmp.
+func writeCredentials(t *testing.T, serverURL, token string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	dir := filepath.Join(tmp, ".jitsudo")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	content := "server_url: \"" + serverURL + "\"\n" +
+		"token: \"" + token + "\"\n" +
+		"expires_at: 2099-01-01T00:00:00Z\n" +
+		"email: test@example.com\n"
+	if err := os.WriteFile(filepath.Join(dir, "credentials"), []byte(content), 0600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+}
+
+// TestNewClient_NoServerURL_Error verifies that newClient returns a clear,
+// actionable error when no server URL is configured via any mechanism.
+func TestNewClient_NoServerURL_Error(t *testing.T) {
+	setupViperForTest(t)
+
+	// Credentials with empty server_url and a valid token so that the
+	// credentials file is readable but contributes no server URL.
+	writeCredentials(t, "", "valid-token")
+
+	// Ensure the global flags are clean.
+	prev := flags
+	t.Cleanup(func() { flags = prev })
+	flags.serverURL = ""
+	flags.token = ""
+
+	_, err := newClient(context.Background())
+	if err == nil {
+		t.Fatal("expected error when no server URL configured, got nil")
+	}
+	if !strings.Contains(err.Error(), "no server URL configured") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestNewClient_ViperServerURL verifies that JITSUDO_SERVER is picked up via
+// viper and used as the server URL without modifying the login credentials.
+func TestNewClient_ViperServerURL(t *testing.T) {
+	setupViperForTest(t)
+	t.Setenv("JITSUDO_SERVER", "localhost:9443")
+
+	// No credentials file; token supplied directly via flag so LoadCredentials
+	// is not called (both serverURL and token are non-empty).
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	prev := flags
+	t.Cleanup(func() { flags = prev })
+	flags.serverURL = ""
+	flags.token = "test-token"
+
+	c, err := newClient(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error with JITSUDO_SERVER set, got: %v", err)
+	}
+	defer c.Close()
+}
+
+// TestNewClient_FlagOverridesViper verifies that --server takes priority over
+// the JITSUDO_SERVER env var.
+func TestNewClient_FlagOverridesViper(t *testing.T) {
+	setupViperForTest(t)
+	t.Setenv("JITSUDO_SERVER", "env-server:9000")
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	prev := flags
+	t.Cleanup(func() { flags = prev })
+	flags.serverURL = "flag-server:8443"
+	flags.token = "test-token"
+
+	// If --server flag is set it should be used; the env var value should not
+	// cause an error or override the explicit flag.
+	c, err := newClient(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error with --server flag set, got: %v", err)
+	}
+	defer c.Close()
+}


### PR DESCRIPTION
Closes #6

## Summary

- **`root.go`**: Fall back to `viper.GetString("server")` for the server URL, which automatically reads `JITSUDO_SERVER` from the environment (via the existing `SetEnvPrefix("JITSUDO")` + `AutomaticEnv()` already in place). Also adds an actionable error message when no server URL is configured.
- **`request.go`**: `--duration` now defaults to `1h` and is no longer required. `--reason` is no longer required — enforcement belongs in OPA policy.
- **`request_test.go`** / **`root_test.go`**: New tests for flag defaults, required-flag annotations, env var pickup, and the error message.

## Changes

| File | Change |
|------|--------|
| `internal/cli/root.go` | `JITSUDO_SERVER` env var + config file fallback; actionable "no server URL" error |
| `internal/cli/request.go` | `--duration` default `1h`, `--reason` optional |
| `internal/cli/request_test.go` | Tests for flag defaults and required-flag annotations |
| `internal/cli/root_test.go` | Tests for env var pickup, flag priority, no-server error |

## Test plan

- [ ] `go test ./internal/cli/...` passes
- [ ] `export JITSUDO_SERVER=http://localhost:8080 && make docker-up && jitsudo login --provider http://localhost:5556/dex && jitsudo request --provider mock --role test-role --scope test-scope` — no error
- [ ] Unset `JITSUDO_SERVER`, run `jitsudo request ...` — confirm actionable error message
