### PR TITLE
fix(client): strip http/https scheme from ServerURL before dialling gRPC

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net/url"
 	"os"
 
 	"google.golang.org/grpc"
@@ -58,6 +59,13 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 		return nil, fmt.Errorf("client: ServerURL is required")
 	}
 
+	// grpc.NewClient expects a bare host:port target, not a URL with scheme.
+	// Strip http:// or https:// so that users can supply either form.
+	target := cfg.ServerURL
+	if u, err := url.Parse(target); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+		target = u.Host
+	}
+
 	dialOpts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(bearerInterceptor(cfg.Token)),
 	}
@@ -76,9 +84,9 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 	}
 
-	conn, err := grpc.NewClient(cfg.ServerURL, dialOpts...)
+	conn, err := grpc.NewClient(target, dialOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("client: dial %q: %w", cfg.ServerURL, err)
+		return nil, fmt.Errorf("client: dial %q: %w", target, err)
 	}
 
 	return &Client{

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNew_StripHTTPScheme verifies that New accepts full http:// and https://
+// URLs and strips the scheme before dialling, avoiding the "too many colons"
+// error from grpc.NewClient.
+func TestNew_StripHTTPScheme(t *testing.T) {
+	cases := []struct {
+		name      string
+		serverURL string
+	}{
+		{"http scheme", "http://localhost:8080"},
+		{"https scheme", "https://localhost:8443"},
+		{"bare host:port", "localhost:8080"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := New(context.Background(), Config{
+				ServerURL: tc.serverURL,
+				Token:     "test-token",
+				Insecure:  true,
+			})
+			if err != nil {
+				t.Fatalf("New(%q) error: %v", tc.serverURL, err)
+			}
+			c.Close()
+		})
+	}
+}
+
+func TestNew_EmptyServerURL(t *testing.T) {
+	_, err := New(context.Background(), Config{})
+	if err == nil {
+		t.Fatal("expected error for empty ServerURL, got nil")
+	}
+}


### PR DESCRIPTION
Closes #9

## Root cause

`grpc.NewClient` expects a bare `host:port` target. When `ServerURL` contains an `http://` or `https://` scheme (as users naturally write it), gRPC treats the whole string as a hostname and appends port 443, producing `http://localhost:8080:443` — causing the "too many colons in address" error.

## Fix

In `pkg/client/client.go`, strip the scheme with `url.Parse` before passing to `grpc.NewClient`. Both `http://localhost:8080` and bare `localhost:8080` now work transparently.

## Changes

| File | Change |
|------|--------|
| `pkg/client/client.go` | Strip `http://`/`https://` scheme before dialling |
| `pkg/client/client_test.go` | Tests for all three URL forms + empty URL error |

## Test plan

- [ ] `go test ./pkg/client/...` passes
- [ ] `export JITSUDO_SERVER=http://localhost:8080 && make docker-up && jitsudo login --provider http://localhost:5556/dex && jitsudo request --provider mock --role test-role --scope test-scope` — no error