### PR TITLE
fix(auth): rewrite JWKS fetches to DiscoveryURL host when issuer host differs

### DIFF
--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -9,6 +9,8 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
@@ -43,6 +45,12 @@ type Verifier struct {
 // deployments where the OIDC provider is reachable only via an internal address
 // (e.g. Docker service name) while tokens use a public or host-facing issuer URL.
 //
+// When the two URLs have different hosts (e.g. "localhost:5556" vs "dex:5556"), a
+// host-rewriting HTTP transport is injected so that JWKS fetches — which use the
+// issuer URL reported inside the discovery document — are transparently redirected
+// to the reachable discovery host. Without this, go-oidc would try to fetch JWKS
+// from the issuer host, which may be unreachable from inside a Docker network.
+//
 // Security note: cfg.DiscoveryURL MUST point to the same OIDC provider as cfg.Issuer.
 // Setting it to a different provider's endpoint would allow that provider's keys to be
 // used for verification, which is a security vulnerability. This option exists only to
@@ -52,6 +60,22 @@ func NewVerifier(ctx context.Context, cfg Config) (*Verifier, error) {
 	if cfg.DiscoveryURL != "" {
 		discoveryURL = cfg.DiscoveryURL
 		ctx = gooidc.InsecureIssuerURLContext(ctx, cfg.Issuer)
+
+		// If the issuer and discovery hosts differ, rewrite all OIDC HTTP requests
+		// (including JWKS fetches) from the issuer host to the discovery host.
+		// go-oidc captures the context's HTTP client at NewProvider time and reuses
+		// it for all subsequent key set fetches, so this one injection is sufficient.
+		issuerHost := hostOf(cfg.Issuer)
+		discoveryHost := hostOf(cfg.DiscoveryURL)
+		if issuerHost != "" && discoveryHost != "" && issuerHost != discoveryHost {
+			ctx = gooidc.ClientContext(ctx, &http.Client{
+				Transport: &hostRewriteTransport{
+					from:    issuerHost,
+					to:      discoveryHost,
+					wrapped: http.DefaultTransport,
+				},
+			})
+		}
 	}
 	provider, err := gooidc.NewProvider(ctx, discoveryURL)
 	if err != nil {
@@ -59,6 +83,33 @@ func NewVerifier(ctx context.Context, cfg Config) (*Verifier, error) {
 	}
 	v := provider.Verifier(&gooidc.Config{ClientID: cfg.ClientID})
 	return &Verifier{verifier: v}, nil
+}
+
+// hostOf extracts the host:port from a URL string, returning "" on parse error.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// hostRewriteTransport is an http.RoundTripper that rewrites requests whose
+// host matches `from` to use `to` instead. Used to redirect OIDC JWKS fetches
+// from the public issuer host to an internally-reachable discovery host.
+type hostRewriteTransport struct {
+	from    string // host[:port] to replace, e.g. "localhost:5556"
+	to      string // replacement host[:port], e.g. "dex:5556"
+	wrapped http.RoundTripper
+}
+
+func (t *hostRewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Host == t.from {
+		r2 := r.Clone(r.Context())
+		r2.URL.Host = t.to
+		r = r2
+	}
+	return t.wrapped.RoundTrip(r)
 }
 
 // Verify validates rawToken and returns the extracted Identity.

--- a/internal/server/auth/transport_test.go
+++ b/internal/server/auth/transport_test.go
@@ -1,0 +1,80 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+// Internal tests for unexported transport helpers.
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHostRewriteTransport_RewritesMatchingHost(t *testing.T) {
+	// Target server: responds 200 when reached.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	// targetHost is e.g. "127.0.0.1:PORT"
+	targetHost := target.Listener.Addr().String()
+
+	rt := &hostRewriteTransport{
+		from:    "unreachable.internal:5556",
+		to:      targetHost,
+		wrapped: http.DefaultTransport,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://unreachable.internal:5556/dex/keys", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHostRewriteTransport_PassesThroughNonMatchingHost(t *testing.T) {
+	// Server to be reached directly (non-matching host).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	rt := &hostRewriteTransport{
+		from:    "other.host:9999",
+		to:      "should-not-be-used:0",
+		wrapped: http.DefaultTransport,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/path", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHostOf(t *testing.T) {
+	cases := []struct {
+		rawURL string
+		want   string
+	}{
+		{"http://localhost:5556/dex", "localhost:5556"},
+		{"http://dex:5556/dex", "dex:5556"},
+		{"https://example.com/path", "example.com"},
+		{"not-a-url", ""},
+	}
+	for _, tc := range cases {
+		got := hostOf(tc.rawURL)
+		if got != tc.want {
+			t.Errorf("hostOf(%q) = %q, want %q", tc.rawURL, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #12

## Root cause

With `make docker-up`, jitsudod is inside Docker and cannot reach `localhost:5556`. `JITSUDOD_OIDC_DISCOVERY_URL=http://dex:5556/dex` lets `NewVerifier` fetch the discovery document via Docker-internal DNS — but the JWKS URI _inside_ that document still says `http://localhost:5556/dex/keys`. When go-oidc fetches JWKS to verify a token signature, it follows that URI and fails with `connection refused`.

## Fix

When `Issuer` and `DiscoveryURL` have different hosts, inject a `hostRewriteTransport` (via `gooidc.ClientContext`) that transparently rewrites requests to the issuer host to use the discovery host. go-oidc captures the context's HTTP client at `NewProvider` time and reuses it for all subsequent JWKS fetches, so one injection is sufficient.

## Changes

| File | Change |
|------|--------|
| `internal/server/auth/auth.go` | `hostRewriteTransport`, `hostOf`, host-rewrite injection in `NewVerifier` |
| `internal/server/auth/transport_test.go` | Unit tests for `hostRewriteTransport` and `hostOf` |

## Test plan

- [ ] `go test ./internal/server/auth/...` passes (7 tests)
- [ ] `make docker-up && JITSUDO_SERVER=localhost:8443 jitsudo request --provider mock --role test-role --scope test-scope` returns a request ID