### PR TITLE
fix(exec): remove doubled "exec:" prefix in command-not-found error

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -61,7 +61,7 @@ provider-specific credential variables (e.g., MOCK_ACCESS_KEY for the mock provi
 				if exitErr, ok := err.(*exec.ExitError); ok {
 					os.Exit(exitErr.ExitCode())
 				}
-				return fmt.Errorf("exec: %w", err)
+				return err
 			}
 			return nil
 		},

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1,0 +1,53 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestExecCmd_CommandNotFoundNoDuplicatePrefix verifies that when a subprocess
+// command is not found, the error message does not have the doubled "exec: exec:"
+// prefix that occurred when we wrapped os/exec errors with fmt.Errorf("exec: %w", err).
+//
+// os/exec already prefixes command-not-found errors with "exec:". Cobra further
+// prefixes the RunE return value with the subcommand name "exec:". Wrapping the
+// error ourselves produced the triple-prefixed message:
+//
+//	Error: exec: exec: "cmd": executable file not found in $PATH
+//
+// Returning the os/exec error directly gives the correct two-level message:
+//
+//	Error: exec: "cmd": executable file not found in $PATH
+func TestExecCmd_CommandNotFoundNoDuplicatePrefix(t *testing.T) {
+	const notFound = "definitely-not-a-real-command-for-jitsudo-testing"
+
+	// Confirm os/exec returns an "exec: ..." error for a missing command.
+	osExecErr := exec.Command(notFound).Run()
+	if osExecErr == nil {
+		t.Skipf("command %q unexpectedly found in PATH", notFound)
+	}
+
+	errStr := osExecErr.Error()
+	if !strings.HasPrefix(errStr, "exec: ") {
+		t.Fatalf("expected os/exec error to start with \"exec: \", got: %q", errStr)
+	}
+
+	// Demonstrate that wrapping with fmt.Errorf("exec: %w") doubles the prefix —
+	// this is the bug that was fixed.
+	wrapped := fmt.Errorf("exec: %w", osExecErr)
+	if !strings.HasPrefix(wrapped.Error(), "exec: exec: ") {
+		t.Errorf("sanity: wrapped error should start with \"exec: exec: \", got: %q", wrapped.Error())
+	}
+
+	// The fix: return the os/exec error directly. Cobra prepends the subcommand
+	// name "exec:" when printing, producing exactly one "exec:" from the error
+	// itself. Verify the raw error does NOT already start with "exec: exec:".
+	if strings.HasPrefix(errStr, "exec: exec: ") {
+		t.Errorf("os/exec error has unexpected double prefix: %q", errStr)
+	}
+}


### PR DESCRIPTION
## Summary

- `jitsudo exec <id> -- nonexistent-cmd` previously printed `Error: exec: exec: "nonexistent-cmd": executable file not found in $PATH`
- `os/exec` already prefixes command-not-found errors with `exec:`; Cobra further prepends the subcommand name `exec:` when printing `RunE` errors
- Wrapping the error with `fmt.Errorf("exec: %w", err)` produced a third `exec:`, giving the double-prefix message
- Fix: return the `os/exec` error directly, letting Cobra's single prefix stand

## Test plan

- [ ] `go test ./internal/cli/` passes
- [ ] `jitsudo exec <active-request> -- nonexistent-cmd` prints `Error: exec: "nonexistent-cmd": executable file not found in $PATH` (one prefix only)

Closes #17