### PR TITLE
fix(audit): add -o shorthand for --output; error on unknown format

### DIFF
--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -77,12 +77,14 @@ func newAuditCmd() *cobra.Command {
 			}
 
 			switch output {
+			case "table":
+				return printAuditTable(cmd.OutOrStdout(), events)
 			case "json":
 				return printAuditJSON(cmd.OutOrStdout(), events)
 			case "csv":
 				return printAuditCSV(cmd.OutOrStdout(), events)
 			default:
-				return printAuditTable(cmd.OutOrStdout(), events)
+				return fmt.Errorf("unknown --output format %q: choose table, json, or csv", output)
 			}
 		},
 	}
@@ -92,7 +94,7 @@ func newAuditCmd() *cobra.Command {
 	cmd.Flags().StringVar(&requestID, "request", "", "Filter by request ID")
 	cmd.Flags().StringVar(&since, "since", "", "Return events after this duration or timestamp (e.g. 24h, 2026-01-01T00:00:00Z)")
 	cmd.Flags().StringVar(&until, "until", "", "Return events before this RFC3339 timestamp")
-	cmd.Flags().StringVar(&output, "output", "table", "Output format: table, json, csv")
+	cmd.Flags().StringVarP(&output, "output", "o", "table", "Output format: table, json, csv")
 
 	return cmd
 }

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAuditCmd_OutputFlagHasShorthand(t *testing.T) {
+	cmd := newAuditCmd()
+	f := cmd.Flags().ShorthandLookup("o")
+	if f == nil {
+		t.Fatal("audit command is missing -o shorthand for --output")
+	}
+	if f.Name != "output" {
+		t.Errorf("-o shorthand maps to %q, want \"output\"", f.Name)
+	}
+}
+
+func TestAuditCmd_OutputFlagDefault(t *testing.T) {
+	cmd := newAuditCmd()
+	f := cmd.Flags().Lookup("output")
+	if f == nil {
+		t.Fatal("--output flag not defined on audit command")
+	}
+	if f.DefValue != "table" {
+		t.Errorf("default --output = %q, want \"table\"", f.DefValue)
+	}
+}
+
+func TestAuditCmd_OutputFlagDescription(t *testing.T) {
+	cmd := newAuditCmd()
+	f := cmd.Flags().Lookup("output")
+	if f == nil {
+		t.Fatal("--output flag not defined on audit command")
+	}
+	// Confirm the flag description mentions the supported formats.
+	for _, want := range []string{"table", "json", "csv"} {
+		if !strings.Contains(f.Usage, want) {
+			t.Errorf("--output usage does not mention %q: %s", want, f.Usage)
+		}
+	}
+}
+
+func TestAuditCmd_OutputShorthandNotConflictsWithGlobal(t *testing.T) {
+	// The audit command defines its own -o, --output local flag which shadows
+	// the global persistent -o. Cobra should resolve -o to the local flag.
+	cmd := newAuditCmd()
+	f := cmd.Flags().ShorthandLookup("o")
+	if f == nil {
+		t.Fatal("-o shorthand not found on audit command")
+	}
+	_, isRequired := f.Annotations[cobra.BashCompOneRequiredFlag]
+	if isRequired {
+		t.Error("--output should not be required")
+	}
+}


### PR DESCRIPTION
## Summary

- `jitsudo audit -o json` previously failed with `Error: unknown shorthand flag: 'o' in -o` because the `audit` command defined its own `--output` flag without the `-o` shorthand (`StringVar` instead of `StringVarP`)
- `jitsudo audit --output yaml` silently fell through to table output with no error because the switch `default` case rendered table unconditionally

## Changes

- `internal/cli/audit.go`: `StringVar` → `StringVarP` with shorthand `o`; add explicit `"table"` case and a `default` that returns an error for unrecognised formats
- `internal/cli/audit_test.go`: tests for shorthand presence, default value, format description, and required-flag annotation

## Test plan

- [ ] `go test ./internal/cli/` passes
- [ ] `jitsudo audit -o json` outputs JSON
- [ ] `jitsudo audit -o csv` outputs CSV
- [ ] `jitsudo audit -o yaml` returns `Error: unknown --output format "yaml": choose table, json, or csv`

Closes #14