### PR TITLE
fix(cli): wrap gRPC errors with friendlyError to strip wire-level noise

### DIFF
--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -34,7 +34,7 @@ func newApproveCmd() *cobra.Command {
 				Comment:   comment,
 			})
 			if err != nil {
-				return fmt.Errorf("approve: %w", err)
+				return fmt.Errorf("approve: %w", friendlyError(err))
 			}
 
 			req := resp.GetRequest()
@@ -70,7 +70,7 @@ func newDenyCmd() *cobra.Command {
 				Reason:    reason,
 			})
 			if err != nil {
-				return fmt.Errorf("deny: %w", err)
+				return fmt.Errorf("deny: %w", friendlyError(err))
 			}
 
 			req := resp.GetRequest()

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -67,7 +67,7 @@ func newAuditCmd() *cobra.Command {
 
 			resp, err := c.Service().QueryAudit(ctx, queryInput)
 			if err != nil {
-				return fmt.Errorf("audit query: %w", err)
+				return fmt.Errorf("audit query: %w", friendlyError(err))
 			}
 
 			events := resp.GetEvents()

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -1,0 +1,40 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// internalPrefixes are package-path-style prefixes that appear in server error
+// messages but are implementation details not useful to end users.
+var internalPrefixes = []string{
+	"workflow: ",
+	"store: ",
+}
+
+// friendlyError translates a gRPC status error into a user-facing error by
+// stripping the wire-level "rpc error: code = X desc = " wrapper and removing
+// known internal package-name prefixes from the description.
+//
+// Non-gRPC errors are returned unchanged.
+func friendlyError(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	if st.Code() == codes.NotFound {
+		return errors.New("not found")
+	}
+	msg := st.Message()
+	// Strip any leading internal-package prefixes (e.g. "workflow: ", "store: ").
+	for _, prefix := range internalPrefixes {
+		msg = strings.TrimPrefix(msg, prefix)
+	}
+	return errors.New(msg)
+}

--- a/internal/cli/errors_test.go
+++ b/internal/cli/errors_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestFriendlyError_NonGRPC(t *testing.T) {
+	orig := errors.New("plain error")
+	got := friendlyError(orig)
+	if got != orig {
+		t.Errorf("expected same error for non-gRPC error; got %v", got)
+	}
+}
+
+func TestFriendlyError_NotFound(t *testing.T) {
+	err := status.Error(codes.NotFound, "request req_123 not found")
+	got := friendlyError(err)
+	if got.Error() != "not found" {
+		t.Errorf("expected %q; got %q", "not found", got.Error())
+	}
+}
+
+func TestFriendlyError_StripGRPCWrapper(t *testing.T) {
+	err := status.Error(codes.InvalidArgument, "duration must be positive")
+	got := friendlyError(err)
+	if got.Error() != "duration must be positive" {
+		t.Errorf("expected raw message; got %q", got.Error())
+	}
+}
+
+func TestFriendlyError_StripWorkflowPrefix(t *testing.T) {
+	err := status.Error(codes.Internal, "workflow: state machine transition denied")
+	got := friendlyError(err)
+	if got.Error() != "state machine transition denied" {
+		t.Errorf("expected prefix stripped; got %q", got.Error())
+	}
+}
+
+func TestFriendlyError_StripStorePrefix(t *testing.T) {
+	err := status.Error(codes.Internal, "store: database connection failed")
+	got := friendlyError(err)
+	if got.Error() != "database connection failed" {
+		t.Errorf("expected prefix stripped; got %q", got.Error())
+	}
+}
+
+func TestFriendlyError_ChainedPrefixes(t *testing.T) {
+	// Both known prefixes should be stripped when chained (e.g. wrapped errors).
+	err := status.Error(codes.Internal, "workflow: store: nested prefix")
+	got := friendlyError(err)
+	if got.Error() != "nested prefix" {
+		t.Errorf("expected both chained prefixes stripped; got %q", got.Error())
+	}
+}
+
+func TestFriendlyError_UnknownGRPCCode(t *testing.T) {
+	err := status.Error(codes.PermissionDenied, "not authorized")
+	got := friendlyError(err)
+	if got.Error() != "not authorized" {
+		t.Errorf("expected message for unknown code; got %q", got.Error())
+	}
+}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -42,7 +42,7 @@ provider-specific credential variables (e.g., MOCK_ACCESS_KEY for the mock provi
 				RequestId: requestID,
 			})
 			if err != nil {
-				return fmt.Errorf("get credentials: %w", err)
+				return fmt.Errorf("get credentials: %w", friendlyError(err))
 			}
 
 			// Build environment: inherit parent env + inject credentials.

--- a/internal/cli/policy.go
+++ b/internal/cli/policy.go
@@ -47,7 +47,7 @@ func newPolicyListCmd() *cobra.Command {
 
 			resp, err := c.Service().ListPolicies(ctx, &jitsudov1alpha1.ListPoliciesInput{})
 			if err != nil {
-				return fmt.Errorf("list policies: %w", err)
+				return fmt.Errorf("list policies: %w", friendlyError(err))
 			}
 
 			policies := resp.GetPolicies()
@@ -85,7 +85,7 @@ func newPolicyGetCmd() *cobra.Command {
 
 			resp, err := c.Service().GetPolicy(ctx, &jitsudov1alpha1.GetPolicyInput{Id: args[0]})
 			if err != nil {
-				return fmt.Errorf("get policy: %w", err)
+				return fmt.Errorf("get policy: %w", friendlyError(err))
 			}
 
 			p := resp.GetPolicy()
@@ -155,7 +155,7 @@ func newPolicyApplyCmd() *cobra.Command {
 				Enabled:     !disable,
 			})
 			if err != nil {
-				return fmt.Errorf("apply policy: %w", err)
+				return fmt.Errorf("apply policy: %w", friendlyError(err))
 			}
 
 			p := resp.GetPolicy()
@@ -191,7 +191,7 @@ func newPolicyDeleteCmd() *cobra.Command {
 
 			_, err = c.Service().DeletePolicy(ctx, &jitsudov1alpha1.DeletePolicyInput{Id: args[0]})
 			if err != nil {
-				return fmt.Errorf("delete policy: %w", err)
+				return fmt.Errorf("delete policy: %w", friendlyError(err))
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Policy %s deleted.\n", args[0])
@@ -237,7 +237,7 @@ making any state changes. The input must match the OPA input structure:
 				Type:      pt,
 			})
 			if err != nil {
-				return fmt.Errorf("eval policy: %w", err)
+				return fmt.Errorf("eval policy: %w", friendlyError(err))
 			}
 
 			out := cmd.OutOrStdout()

--- a/internal/cli/revoke.go
+++ b/internal/cli/revoke.go
@@ -34,7 +34,7 @@ func newRevokeCmd() *cobra.Command {
 				Reason:    reason,
 			})
 			if err != nil {
-				return fmt.Errorf("revoke: %w", err)
+				return fmt.Errorf("revoke: %w", friendlyError(err))
 			}
 
 			req := resp.GetRequest()

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -42,7 +42,7 @@ func newStatusCmd() *cobra.Command {
 					Id: args[0],
 				})
 				if err != nil {
-					return fmt.Errorf("get request: %w", err)
+					return fmt.Errorf("get request: %w", friendlyError(err))
 				}
 				printRequest(out, resp.GetRequest())
 				return nil
@@ -54,7 +54,7 @@ func newStatusCmd() *cobra.Command {
 			}
 			resp, err := c.Service().ListRequests(ctx, filter)
 			if err != nil {
-				return fmt.Errorf("list requests: %w", err)
+				return fmt.Errorf("list requests: %w", friendlyError(err))
 			}
 
 			requests := resp.GetRequests()


### PR DESCRIPTION
## Summary

- Introduces `friendlyError()` in `internal/cli/errors.go` that translates raw gRPC status errors into clean user-facing messages: strips the `rpc error: code = X desc =` wire wrapper, returns `"not found"` for `NotFound` codes, and removes internal package-name prefixes (`"workflow: "`, `"store: "`)
- Applies `friendlyError()` to every gRPC call site in the CLI: `approve`, `audit`, `deny`, `exec`, `policy` (list/get/apply/delete/eval), `revoke`, and `status`
- Adds `errors_test.go` with 7 unit tests covering all branches of `friendlyError()`

Fixes #16

## Test plan

- [ ] `go test ./internal/cli/...` passes
- [ ] `jitsudo status req_nonexistent` prints `get request: not found` instead of `rpc error: code = NotFound desc = ...`
- [ ] `jitsudo approve req_pending_but_already_active` prints a clean `approve: request already approved` message (no gRPC wrapper)
- [ ] `jitsudo policy get pol_nonexistent` prints `get policy: not found`