### PR TITLE
feat(cli): honour --output/-o flag in status, request, policy list/get

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -15,31 +15,31 @@ import (
 
 // requestRow is the JSON/YAML representation of an ElevationRequest.
 type requestRow struct {
-	ID               string `json:"id" yaml:"id"`
-	State            string `json:"state" yaml:"state"`
+	ID                string `json:"id" yaml:"id"`
+	State             string `json:"state" yaml:"state"`
 	RequesterIdentity string `json:"requester_identity" yaml:"requester_identity"`
-	Provider         string `json:"provider" yaml:"provider"`
-	Role             string `json:"role" yaml:"role"`
-	ResourceScope    string `json:"resource_scope" yaml:"resource_scope"`
-	DurationSeconds  int64  `json:"duration_seconds" yaml:"duration_seconds"`
-	Reason           string `json:"reason" yaml:"reason"`
-	ApproverIdentity string `json:"approver_identity,omitempty" yaml:"approver_identity,omitempty"`
-	ApproverComment  string `json:"approver_comment,omitempty" yaml:"approver_comment,omitempty"`
-	ExpiresAt        string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+	Provider          string `json:"provider" yaml:"provider"`
+	Role              string `json:"role" yaml:"role"`
+	ResourceScope     string `json:"resource_scope" yaml:"resource_scope"`
+	DurationSeconds   int64  `json:"duration_seconds" yaml:"duration_seconds"`
+	Reason            string `json:"reason" yaml:"reason"`
+	ApproverIdentity  string `json:"approver_identity,omitempty" yaml:"approver_identity,omitempty"`
+	ApproverComment   string `json:"approver_comment,omitempty" yaml:"approver_comment,omitempty"`
+	ExpiresAt         string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 }
 
 func requestToRow(r *jitsudov1alpha1.ElevationRequest) requestRow {
 	row := requestRow{
-		ID:               r.GetId(),
-		State:            stateString(r.GetState()),
+		ID:                r.GetId(),
+		State:             stateString(r.GetState()),
 		RequesterIdentity: r.GetRequesterIdentity(),
-		Provider:         r.GetProvider(),
-		Role:             r.GetRole(),
-		ResourceScope:    r.GetResourceScope(),
-		DurationSeconds:  r.GetDurationSeconds(),
-		Reason:           r.GetReason(),
-		ApproverIdentity: r.GetApproverIdentity(),
-		ApproverComment:  r.GetApproverComment(),
+		Provider:          r.GetProvider(),
+		Role:              r.GetRole(),
+		ResourceScope:     r.GetResourceScope(),
+		DurationSeconds:   r.GetDurationSeconds(),
+		Reason:            r.GetReason(),
+		ApproverIdentity:  r.GetApproverIdentity(),
+		ApproverComment:   r.GetApproverComment(),
 	}
 	if r.GetExpiresAt() != nil {
 		row.ExpiresAt = r.GetExpiresAt().AsTime().UTC().Format(time.RFC3339)

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,86 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	jitsudov1alpha1 "github.com/jitsudo-dev/jitsudo/internal/gen/proto/go/jitsudo/v1alpha1"
+)
+
+// requestRow is the JSON/YAML representation of an ElevationRequest.
+type requestRow struct {
+	ID               string `json:"id" yaml:"id"`
+	State            string `json:"state" yaml:"state"`
+	RequesterIdentity string `json:"requester_identity" yaml:"requester_identity"`
+	Provider         string `json:"provider" yaml:"provider"`
+	Role             string `json:"role" yaml:"role"`
+	ResourceScope    string `json:"resource_scope" yaml:"resource_scope"`
+	DurationSeconds  int64  `json:"duration_seconds" yaml:"duration_seconds"`
+	Reason           string `json:"reason" yaml:"reason"`
+	ApproverIdentity string `json:"approver_identity,omitempty" yaml:"approver_identity,omitempty"`
+	ApproverComment  string `json:"approver_comment,omitempty" yaml:"approver_comment,omitempty"`
+	ExpiresAt        string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+}
+
+func requestToRow(r *jitsudov1alpha1.ElevationRequest) requestRow {
+	row := requestRow{
+		ID:               r.GetId(),
+		State:            stateString(r.GetState()),
+		RequesterIdentity: r.GetRequesterIdentity(),
+		Provider:         r.GetProvider(),
+		Role:             r.GetRole(),
+		ResourceScope:    r.GetResourceScope(),
+		DurationSeconds:  r.GetDurationSeconds(),
+		Reason:           r.GetReason(),
+		ApproverIdentity: r.GetApproverIdentity(),
+		ApproverComment:  r.GetApproverComment(),
+	}
+	if r.GetExpiresAt() != nil {
+		row.ExpiresAt = r.GetExpiresAt().AsTime().UTC().Format(time.RFC3339)
+	}
+	return row
+}
+
+// policyRow is the JSON/YAML representation of a Policy.
+type policyRow struct {
+	ID          string `json:"id" yaml:"id"`
+	Name        string `json:"name" yaml:"name"`
+	Type        string `json:"type" yaml:"type"`
+	Enabled     bool   `json:"enabled" yaml:"enabled"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	UpdatedAt   string `json:"updated_at" yaml:"updated_at"`
+	Rego        string `json:"rego,omitempty" yaml:"rego,omitempty"`
+}
+
+func policyToRow(p *jitsudov1alpha1.Policy, includeRego bool) policyRow {
+	row := policyRow{
+		ID:          p.GetId(),
+		Name:        p.GetName(),
+		Type:        policyTypeString(p.GetType()),
+		Enabled:     p.GetEnabled(),
+		Description: p.GetDescription(),
+		UpdatedAt:   p.GetUpdatedAt().AsTime().UTC().Format(time.RFC3339),
+	}
+	if includeRego {
+		row.Rego = p.GetRego()
+	}
+	return row
+}
+
+func encodeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func encodeYAML(w io.Writer, v any) error {
+	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
+	return enc.Encode(v)
+}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,130 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/yaml.v3"
+
+	jitsudov1alpha1 "github.com/jitsudo-dev/jitsudo/internal/gen/proto/go/jitsudo/v1alpha1"
+)
+
+// TestOutputFlag_GlobalFlagExists verifies the persistent -o/--output flag is
+// registered on the root command and has the expected default.
+func TestOutputFlag_GlobalFlagExists(t *testing.T) {
+	root := NewRootCmd()
+	f := root.PersistentFlags().Lookup("output")
+	if f == nil {
+		t.Fatal("--output flag not defined on root command")
+	}
+	if f.DefValue != "table" {
+		t.Errorf("default --output = %q, want %q", f.DefValue, "table")
+	}
+	if f.Shorthand != "o" {
+		t.Errorf("--output shorthand = %q, want %q", f.Shorthand, "o")
+	}
+}
+
+// TestEncodeJSON verifies encodeJSON produces valid JSON for a struct.
+func TestEncodeJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := encodeJSON(&buf, map[string]string{"key": "value"}); err != nil {
+		t.Fatalf("encodeJSON: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if got["key"] != "value" {
+		t.Errorf("got %q, want %q", got["key"], "value")
+	}
+}
+
+// TestEncodeYAML verifies encodeYAML produces valid YAML for a struct.
+func TestEncodeYAML(t *testing.T) {
+	var buf bytes.Buffer
+	if err := encodeYAML(&buf, map[string]string{"key": "value"}); err != nil {
+		t.Fatalf("encodeYAML: %v", err)
+	}
+	var got map[string]string
+	if err := yaml.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid YAML: %v\noutput: %s", err, buf.String())
+	}
+	if got["key"] != "value" {
+		t.Errorf("got %q, want %q", got["key"], "value")
+	}
+}
+
+// TestRequestToRow verifies requestToRow maps proto fields to the JSON row.
+func TestRequestToRow(t *testing.T) {
+	r := &jitsudov1alpha1.ElevationRequest{
+		Id:                "req_01",
+		State:             jitsudov1alpha1.RequestState_REQUEST_STATE_PENDING,
+		RequesterIdentity: "alice@example.com",
+		Provider:          "mock",
+		Role:              "test-role",
+		ResourceScope:     "test-scope",
+		DurationSeconds:   3600,
+		Reason:            "testing",
+	}
+	row := requestToRow(r)
+	if row.ID != "req_01" {
+		t.Errorf("ID: got %q", row.ID)
+	}
+	if row.State != "PENDING" {
+		t.Errorf("State: got %q", row.State)
+	}
+	if row.Provider != "mock" {
+		t.Errorf("Provider: got %q", row.Provider)
+	}
+	if row.DurationSeconds != 3600 {
+		t.Errorf("DurationSeconds: got %d", row.DurationSeconds)
+	}
+	if row.ExpiresAt != "" {
+		t.Errorf("ExpiresAt should be empty when nil; got %q", row.ExpiresAt)
+	}
+}
+
+// TestRequestToRow_WithExpiry verifies ExpiresAt is set when the proto field is non-nil.
+func TestRequestToRow_WithExpiry(t *testing.T) {
+	ts := timestamppb.Now()
+	r := &jitsudov1alpha1.ElevationRequest{ExpiresAt: ts}
+	row := requestToRow(r)
+	if row.ExpiresAt == "" {
+		t.Error("ExpiresAt should be non-empty when set")
+	}
+}
+
+// TestPolicyToRow_WithoutRego verifies Rego is omitted when includeRego=false.
+func TestPolicyToRow_WithoutRego(t *testing.T) {
+	p := &jitsudov1alpha1.Policy{
+		Id:      "pol_01",
+		Name:    "test-policy",
+		Type:    jitsudov1alpha1.PolicyType_POLICY_TYPE_ELIGIBILITY,
+		Enabled: true,
+		Rego:    "package test\nallow = true",
+	}
+	row := policyToRow(p, false)
+	if row.Rego != "" {
+		t.Errorf("expected empty Rego when includeRego=false; got %q", row.Rego)
+	}
+}
+
+// TestPolicyToRow_WithRego verifies Rego is included when includeRego=true.
+func TestPolicyToRow_WithRego(t *testing.T) {
+	p := &jitsudov1alpha1.Policy{
+		Id:   "pol_01",
+		Name: "test-policy",
+		Rego: "package test\nallow = true",
+	}
+	row := policyToRow(p, true)
+	if !strings.Contains(row.Rego, "allow") {
+		t.Errorf("expected Rego to be set; got %q", row.Rego)
+	}
+}

--- a/internal/cli/policy.go
+++ b/internal/cli/policy.go
@@ -56,15 +56,31 @@ func newPolicyListCmd() *cobra.Command {
 				return nil
 			}
 
-			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "ID\tNAME\tTYPE\tENABLED\tUPDATED")
-			fmt.Fprintln(w, strings.Repeat("-", 80))
-			for _, p := range policies {
-				updated := p.GetUpdatedAt().AsTime().UTC().Format(time.RFC3339)
-				fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%s\n",
-					p.GetId(), p.GetName(), policyTypeString(p.GetType()), p.GetEnabled(), updated)
+			out := cmd.OutOrStdout()
+			switch flags.output {
+			case "json":
+				rows := make([]policyRow, len(policies))
+				for i, p := range policies {
+					rows[i] = policyToRow(p, false)
+				}
+				return encodeJSON(out, rows)
+			case "yaml":
+				rows := make([]policyRow, len(policies))
+				for i, p := range policies {
+					rows[i] = policyToRow(p, false)
+				}
+				return encodeYAML(out, rows)
+			default:
+				w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+				fmt.Fprintln(w, "ID\tNAME\tTYPE\tENABLED\tUPDATED")
+				fmt.Fprintln(w, strings.Repeat("-", 80))
+				for _, p := range policies {
+					updated := p.GetUpdatedAt().AsTime().UTC().Format(time.RFC3339)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%s\n",
+						p.GetId(), p.GetName(), policyTypeString(p.GetType()), p.GetEnabled(), updated)
+				}
+				return w.Flush()
 			}
-			return w.Flush()
 		},
 	}
 }
@@ -90,14 +106,21 @@ func newPolicyGetCmd() *cobra.Command {
 
 			p := resp.GetPolicy()
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "ID:          %s\n", p.GetId())
-			fmt.Fprintf(out, "Name:        %s\n", p.GetName())
-			fmt.Fprintf(out, "Type:        %s\n", policyTypeString(p.GetType()))
-			fmt.Fprintf(out, "Enabled:     %v\n", p.GetEnabled())
-			fmt.Fprintf(out, "Description: %s\n", p.GetDescription())
-			fmt.Fprintf(out, "Updated:     %s\n", p.GetUpdatedAt().AsTime().UTC().Format(time.RFC3339))
-			fmt.Fprintf(out, "\n--- Rego ---\n%s\n", p.GetRego())
-			return nil
+			switch flags.output {
+			case "json":
+				return encodeJSON(out, policyToRow(p, true))
+			case "yaml":
+				return encodeYAML(out, policyToRow(p, true))
+			default:
+				fmt.Fprintf(out, "ID:          %s\n", p.GetId())
+				fmt.Fprintf(out, "Name:        %s\n", p.GetName())
+				fmt.Fprintf(out, "Type:        %s\n", policyTypeString(p.GetType()))
+				fmt.Fprintf(out, "Enabled:     %v\n", p.GetEnabled())
+				fmt.Fprintf(out, "Description: %s\n", p.GetDescription())
+				fmt.Fprintf(out, "Updated:     %s\n", p.GetUpdatedAt().AsTime().UTC().Format(time.RFC3339))
+				fmt.Fprintf(out, "\n--- Rego ---\n%s\n", p.GetRego())
+				return nil
+			}
 		},
 	}
 }

--- a/internal/cli/request.go
+++ b/internal/cli/request.go
@@ -67,12 +67,19 @@ Upon approval, credentials are issued for the specified duration and automatical
 
 			req := resp.GetRequest()
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "Request ID: %s\nState:      %s\n", req.GetId(), stateString(req.GetState()))
-			if !flags.quiet {
-				fmt.Fprintf(out, "Provider:   %s\nRole:       %s\nScope:      %s\n",
-					req.GetProvider(), req.GetRole(), req.GetResourceScope())
+			switch flags.output {
+			case "json":
+				return encodeJSON(out, requestToRow(req))
+			case "yaml":
+				return encodeYAML(out, requestToRow(req))
+			default:
+				fmt.Fprintf(out, "Request ID: %s\nState:      %s\n", req.GetId(), stateString(req.GetState()))
+				if !flags.quiet {
+					fmt.Fprintf(out, "Provider:   %s\nRole:       %s\nScope:      %s\n",
+						req.GetProvider(), req.GetRole(), req.GetResourceScope())
+				}
+				return nil
 			}
-			return nil
 		},
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -44,8 +44,16 @@ func newStatusCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("get request: %w", err)
 				}
-				printRequest(out, resp.GetRequest())
-				return nil
+				r := resp.GetRequest()
+				switch flags.output {
+				case "json":
+					return encodeJSON(out, requestToRow(r))
+				case "yaml":
+					return encodeYAML(out, requestToRow(r))
+				default:
+					printRequest(out, r)
+					return nil
+				}
 			}
 
 			filter := &jitsudov1alpha1.ListRequestsFilter{
@@ -63,13 +71,28 @@ func newStatusCmd() *cobra.Command {
 				return nil
 			}
 
-			fmt.Fprintf(out, "%-28s %-10s %-25s %s\n", "ID", "STATE", "REQUESTER", "REASON")
-			fmt.Fprintln(out, strings.Repeat("-", 85))
-			for _, r := range requests {
-				fmt.Fprintf(out, "%-28s %-10s %-25s %s\n",
-					r.GetId(), stateString(r.GetState()), r.GetRequesterIdentity(), r.GetReason())
+			switch flags.output {
+			case "json":
+				rows := make([]requestRow, len(requests))
+				for i, r := range requests {
+					rows[i] = requestToRow(r)
+				}
+				return encodeJSON(out, rows)
+			case "yaml":
+				rows := make([]requestRow, len(requests))
+				for i, r := range requests {
+					rows[i] = requestToRow(r)
+				}
+				return encodeYAML(out, rows)
+			default:
+				fmt.Fprintf(out, "%-28s %-10s %-25s %s\n", "ID", "STATE", "REQUESTER", "REASON")
+				fmt.Fprintln(out, strings.Repeat("-", 85))
+				for _, r := range requests {
+					fmt.Fprintf(out, "%-28s %-10s %-25s %s\n",
+						r.GetId(), stateString(r.GetState()), r.GetRequesterIdentity(), r.GetReason())
+				}
+				return nil
 			}
-			return nil
 		},
 	}
 


### PR DESCRIPTION
## Summary

- The global `-o, --output` flag was wired to `flags.output` but never consulted by `status`, `request`, `policy list`, or `policy get` — they always emitted plain text
- Adds `output.go` with shared `requestRow` / `policyRow` structs, `requestToRow` / `policyToRow` converters, and `encodeJSON` / `encodeYAML` helpers
- All five affected commands now dispatch on `flags.output`: `table` (default, unchanged), `json` (indented JSON), `yaml`
- Adds `output_test.go` covering flag registration, encode helpers, and proto→row conversions

Fixes #15

## Test plan

- [ ] `go test ./internal/cli/...` passes
- [ ] `jitsudo status <id> -o json` emits a JSON object with `id`, `state`, `provider`, etc.
- [ ] `jitsudo status --mine -o json` emits a JSON array
- [ ] `jitsudo status <id> -o yaml` emits valid YAML
- [ ] `jitsudo request --provider mock --role r --scope s -o json` emits JSON on create
- [ ] `jitsudo policy list -o json` emits JSON array (no `rego` field)
- [ ] `jitsudo policy get <id> -o json` emits JSON object with `rego` field
- [ ] Default table output is unchanged for all commands
- [ ] Unknown `-o` value falls through to table (existing behaviour)