### PR TITLE
fix(server): pre-flight Rego compile check in ApplyPolicy and DeletePolicy

### DIFF
--- a/internal/server/api/api.go
+++ b/internal/server/api/api.go
@@ -37,6 +37,8 @@ func (h *Handler) isAdmin(identity *auth.Identity) bool {
 type PolicyEngine interface {
 	Reload(ctx context.Context) error
 	EvalRaw(ctx context.Context, ptype store.PolicyType, input map[string]any) (bool, string, error)
+	CompileCheck(ctx context.Context, proposed *store.PolicyRow) error
+	CompileCheckWithout(ctx context.Context, removedID string, ptype store.PolicyType) error
 }
 
 // dataStore is the subset of *store.Store methods called by Handler.
@@ -220,6 +222,11 @@ func (h *Handler) ApplyPolicy(ctx context.Context, in *jitsudov1alpha1.ApplyPoli
 		Enabled:     in.GetEnabled(),
 		UpdatedBy:   identity.Email,
 	}
+	// Pre-flight: validate the Rego compiles alongside the current policy set
+	// before writing to the DB, so a compile error never leaves the DB mutated.
+	if err := h.policy.CompileCheck(ctx, row); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "policy compile: %v", err)
+	}
 	saved, err := h.store.UpsertPolicy(ctx, row)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "apply policy: %v", err)
@@ -234,6 +241,15 @@ func (h *Handler) ApplyPolicy(ctx context.Context, in *jitsudov1alpha1.ApplyPoli
 func (h *Handler) DeletePolicy(ctx context.Context, in *jitsudov1alpha1.DeletePolicyInput) (*jitsudov1alpha1.DeletePolicyResponse, error) {
 	if auth.FromContext(ctx) == nil {
 		return nil, status.Error(codes.Unauthenticated, "not authenticated")
+	}
+	// Fetch the policy to learn its type for the pre-flight compile check.
+	existing, err := h.store.GetPolicy(ctx, in.GetId())
+	if err != nil {
+		return nil, storeErr(err)
+	}
+	// Pre-flight: validate remaining policies still compile after removal.
+	if err := h.policy.CompileCheckWithout(ctx, in.GetId(), existing.Type); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "policy compile: %v", err)
 	}
 	if err := h.store.DeletePolicy(ctx, in.GetId()); err != nil {
 		return nil, storeErr(err)

--- a/internal/server/api/api_test.go
+++ b/internal/server/api/api_test.go
@@ -20,8 +20,9 @@ import (
 // ── mock PolicyEngine ─────────────────────────────────────────────────────────
 
 type mockPolicyEngine struct {
-	reloadErr error
-	evalRaw   func(ctx context.Context, ptype store.PolicyType, input map[string]any) (bool, string, error)
+	reloadErr        error
+	compileCheckErr  error
+	evalRaw          func(ctx context.Context, ptype store.PolicyType, input map[string]any) (bool, string, error)
 }
 
 func (m *mockPolicyEngine) Reload(_ context.Context) error { return m.reloadErr }
@@ -31,12 +32,23 @@ func (m *mockPolicyEngine) EvalRaw(ctx context.Context, ptype store.PolicyType, 
 	}
 	return false, "", nil
 }
+func (m *mockPolicyEngine) CompileCheck(_ context.Context, _ *store.PolicyRow) error {
+	return m.compileCheckErr
+}
+func (m *mockPolicyEngine) CompileCheckWithout(_ context.Context, _ string, _ store.PolicyType) error {
+	return m.compileCheckErr
+}
 
 // ── mock dataStore ────────────────────────────────────────────────────────────
 
 type mockDataStore struct {
 	listPoliciesRows []*store.PolicyRow
 	listPoliciesErr  error
+	getPolicyRow     *store.PolicyRow
+	getPolicyErr     error
+	upsertPolicyRow  *store.PolicyRow
+	upsertPolicyErr  error
+	deletePolicyErr  error
 }
 
 func (m *mockDataStore) GetRequest(_ context.Context, _ string) (*store.RequestRow, error) {
@@ -49,13 +61,19 @@ func (m *mockDataStore) ListPolicies(_ context.Context, _ *store.PolicyType) ([]
 	return m.listPoliciesRows, m.listPoliciesErr
 }
 func (m *mockDataStore) GetPolicy(_ context.Context, _ string) (*store.PolicyRow, error) {
-	return nil, errors.New("not implemented")
+	return m.getPolicyRow, m.getPolicyErr
 }
-func (m *mockDataStore) UpsertPolicy(_ context.Context, _ *store.PolicyRow) (*store.PolicyRow, error) {
-	return nil, errors.New("not implemented")
+func (m *mockDataStore) UpsertPolicy(_ context.Context, p *store.PolicyRow) (*store.PolicyRow, error) {
+	if m.upsertPolicyErr != nil {
+		return nil, m.upsertPolicyErr
+	}
+	if m.upsertPolicyRow != nil {
+		return m.upsertPolicyRow, nil
+	}
+	return p, nil
 }
 func (m *mockDataStore) DeletePolicy(_ context.Context, _ string) error {
-	return errors.New("not implemented")
+	return m.deletePolicyErr
 }
 func (m *mockDataStore) QueryAuditEvents(_ context.Context, _ store.AuditFilter) ([]*store.AuditEventRow, error) {
 	return nil, errors.New("not implemented")
@@ -205,6 +223,84 @@ func TestSetPrincipalTrustTier_MissingIdentity(t *testing.T) {
 	}
 	if code := status.Code(err); code != codes.InvalidArgument {
 		t.Errorf("got %v, want InvalidArgument", code)
+	}
+}
+
+// ── TestApplyPolicy pre-flight ────────────────────────────────────────────────
+
+// TestApplyPolicy_CompileCheckFails verifies that when the pre-flight compile
+// check fails, ApplyPolicy returns InvalidArgument and does NOT call UpsertPolicy.
+func TestApplyPolicy_CompileCheckFails(t *testing.T) {
+	compileErr := errors.New("rego: multiple default rules in package")
+	ds := &mockDataStore{}
+	h := handlerWithMocks(
+		&mockPolicyEngine{compileCheckErr: compileErr},
+		ds,
+	)
+	_, err := h.ApplyPolicy(authedCtx(), &jitsudov1alpha1.ApplyPolicyInput{
+		Name:    "conflict-policy",
+		Type:    jitsudov1alpha1.PolicyType_POLICY_TYPE_ELIGIBILITY,
+		Rego:    "package jitsudo.eligibility\ndefault allow := false",
+		Enabled: true,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("got %v, want InvalidArgument", code)
+	}
+}
+
+// TestApplyPolicy_CompileCheckPasses verifies that a valid policy is stored
+// when the pre-flight compile check succeeds.
+func TestApplyPolicy_CompileCheckPasses(t *testing.T) {
+	saved := &store.PolicyRow{ID: "pol_01", Name: "good-policy", Enabled: true}
+	ds := &mockDataStore{upsertPolicyRow: saved}
+	h := handlerWithMocks(&mockPolicyEngine{}, ds)
+	resp, err := h.ApplyPolicy(authedCtx(), &jitsudov1alpha1.ApplyPolicyInput{
+		Name:    "good-policy",
+		Type:    jitsudov1alpha1.PolicyType_POLICY_TYPE_ELIGIBILITY,
+		Rego:    "package jitsudo.eligibility\ndefault allow := true",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.GetPolicy().GetId() != "pol_01" {
+		t.Errorf("policy ID = %q, want %q", resp.GetPolicy().GetId(), "pol_01")
+	}
+}
+
+// ── TestDeletePolicy pre-flight ───────────────────────────────────────────────
+
+// TestDeletePolicy_CompileCheckFails verifies that when the pre-flight compile
+// check fails, DeletePolicy returns InvalidArgument and does NOT delete from DB.
+func TestDeletePolicy_CompileCheckFails(t *testing.T) {
+	compileErr := errors.New("rego: remaining policies conflict")
+	existing := &store.PolicyRow{ID: "pol_01", Type: store.PolicyTypeEligibility}
+	ds := &mockDataStore{getPolicyRow: existing}
+	h := handlerWithMocks(
+		&mockPolicyEngine{compileCheckErr: compileErr},
+		ds,
+	)
+	_, err := h.DeletePolicy(authedCtx(), &jitsudov1alpha1.DeletePolicyInput{Id: "pol_01"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("got %v, want InvalidArgument", code)
+	}
+}
+
+// TestDeletePolicy_CompileCheckPasses verifies that a policy is deleted when
+// the pre-flight compile check succeeds.
+func TestDeletePolicy_CompileCheckPasses(t *testing.T) {
+	existing := &store.PolicyRow{ID: "pol_01", Type: store.PolicyTypeEligibility}
+	ds := &mockDataStore{getPolicyRow: existing}
+	h := handlerWithMocks(&mockPolicyEngine{}, ds)
+	_, err := h.DeletePolicy(authedCtx(), &jitsudov1alpha1.DeletePolicyInput{Id: "pol_01"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/server/api/api_test.go
+++ b/internal/server/api/api_test.go
@@ -20,9 +20,9 @@ import (
 // ── mock PolicyEngine ─────────────────────────────────────────────────────────
 
 type mockPolicyEngine struct {
-	reloadErr        error
-	compileCheckErr  error
-	evalRaw          func(ctx context.Context, ptype store.PolicyType, input map[string]any) (bool, string, error)
+	reloadErr       error
+	compileCheckErr error
+	evalRaw         func(ctx context.Context, ptype store.PolicyType, input map[string]any) (bool, string, error)
 }
 
 func (m *mockPolicyEngine) Reload(_ context.Context) error { return m.reloadErr }

--- a/internal/server/policy/policy.go
+++ b/internal/server/policy/policy.go
@@ -116,20 +116,73 @@ func (e *Engine) EvalRaw(ctx context.Context, ptype store.PolicyType, input map[
 	return e.eval(ctx, q, input)
 }
 
-// buildQuery compiles all enabled policies of ptype into a PreparedEvalQuery.
-func (e *Engine) buildQuery(ctx context.Context, ptype store.PolicyType, query string) (*rego.PreparedEvalQuery, error) {
+// CompileCheck tries to compile the proposed policy alongside the current
+// enabled policies of its type. Returns a non-nil error if the combined set
+// does not compile, so callers can reject the request before writing to the DB.
+func (e *Engine) CompileCheck(ctx context.Context, proposed *store.PolicyRow) error {
+	policies, err := e.store.ListEnabledPoliciesByType(ctx, proposed.Type)
+	if err != nil {
+		return fmt.Errorf("policy: compile check: %w", err)
+	}
+	// Build module map; the proposed policy replaces any same-named existing one.
+	modules := make(map[string]string, len(policies)+1)
+	for _, p := range policies {
+		modules[p.Name+".rego"] = p.Rego
+	}
+	if proposed.Enabled {
+		modules[proposed.Name+".rego"] = proposed.Rego
+	}
+	// Check all queries relevant to this policy type.
+	queries := []string{"data.jitsudo.eligibility.allow"}
+	if proposed.Type == store.PolicyTypeApproval {
+		queries = []string{
+			"data.jitsudo.approval.allow",
+			"data.jitsudo.approval.approver_tier",
+		}
+	}
+	for _, q := range queries {
+		if _, err := compileModules(ctx, proposed.Type, q, modules); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CompileCheckWithout tries to compile the current enabled policies of ptype
+// with the policy identified by removedID excluded. Returns a non-nil error if
+// the remaining set does not compile.
+func (e *Engine) CompileCheckWithout(ctx context.Context, removedID string, ptype store.PolicyType) error {
 	policies, err := e.store.ListEnabledPoliciesByType(ctx, ptype)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("policy: compile check: %w", err)
 	}
-
-	opts := []func(*rego.Rego){rego.Query(query)}
+	modules := make(map[string]string, len(policies))
 	for _, p := range policies {
-		opts = append(opts, rego.Module(p.Name+".rego", p.Rego))
+		if p.ID != removedID {
+			modules[p.Name+".rego"] = p.Rego
+		}
 	}
+	queries := []string{"data.jitsudo.eligibility.allow"}
+	if ptype == store.PolicyTypeApproval {
+		queries = []string{
+			"data.jitsudo.approval.allow",
+			"data.jitsudo.approval.approver_tier",
+		}
+	}
+	for _, q := range queries {
+		if _, err := compileModules(ctx, ptype, q, modules); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-	// If no policies are loaded, use a deny-all default so the system is safe.
-	if len(policies) == 0 {
+// compileModules compiles the provided module map for the given query and
+// returns the prepared query. modules maps filename → Rego source. If modules
+// is empty a deny-all default is substituted so the query still compiles.
+func compileModules(ctx context.Context, ptype store.PolicyType, query string, modules map[string]string) (*rego.PreparedEvalQuery, error) {
+	opts := []func(*rego.Rego){rego.Query(query)}
+	if len(modules) == 0 {
 		var pkg string
 		if ptype == store.PolicyTypeEligibility {
 			pkg = "jitsudo.eligibility"
@@ -138,13 +191,33 @@ func (e *Engine) buildQuery(ctx context.Context, ptype store.PolicyType, query s
 		}
 		opts = append(opts, rego.Module("default_deny.rego",
 			fmt.Sprintf("package %s\ndefault allow := false", pkg)))
+	} else {
+		for name, src := range modules {
+			opts = append(opts, rego.Module(name, src))
+		}
 	}
-
 	pq, err := rego.New(opts...).PrepareForEval(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("policy: compile: %w", err)
+	}
+	return &pq, nil
+}
+
+// buildQuery compiles all enabled policies of ptype into a PreparedEvalQuery.
+func (e *Engine) buildQuery(ctx context.Context, ptype store.PolicyType, query string) (*rego.PreparedEvalQuery, error) {
+	policies, err := e.store.ListEnabledPoliciesByType(ctx, ptype)
+	if err != nil {
+		return nil, err
+	}
+	modules := make(map[string]string, len(policies))
+	for _, p := range policies {
+		modules[p.Name+".rego"] = p.Rego
+	}
+	pq, err := compileModules(ctx, ptype, query, modules)
 	if err != nil {
 		return nil, fmt.Errorf("policy: compile %s: %w", ptype, err)
 	}
-	return &pq, nil
+	return pq, nil
 }
 
 // eval runs a prepared query and extracts the allow + reason values.

--- a/internal/server/policy/policy_test.go
+++ b/internal/server/policy/policy_test.go
@@ -186,6 +186,66 @@ approver_tier := "auto" if {
 	}
 }
 
+// ── compileModules tests ─────────────────────────────────────────────────────
+
+// TestCompileModules_ValidEligibility verifies that a valid eligibility policy compiles.
+func TestCompileModules_ValidEligibility(t *testing.T) {
+	modules := map[string]string{
+		"allow-sre.rego": `
+package jitsudo.eligibility
+import rego.v1
+default allow := false
+allow if { input.user.groups[_] == "sre" }
+`,
+	}
+	_, err := compileModules(context.Background(), store.PolicyTypeEligibility, "data.jitsudo.eligibility.allow", modules)
+	if err != nil {
+		t.Fatalf("expected compile success; got: %v", err)
+	}
+}
+
+// TestCompileModules_ConflictingDefaultRules verifies that two policies with
+// conflicting default rules produce a compile error.
+func TestCompileModules_ConflictingDefaultRules(t *testing.T) {
+	modules := map[string]string{
+		"policy-a.rego": "package jitsudo.eligibility\ndefault allow := true",
+		"policy-b.rego": "package jitsudo.eligibility\ndefault allow := false",
+	}
+	_, err := compileModules(context.Background(), store.PolicyTypeEligibility, "data.jitsudo.eligibility.allow", modules)
+	if err == nil {
+		t.Fatal("expected compile error for conflicting default rules, got nil")
+	}
+}
+
+// TestCompileModules_EmptyModulesDenyAll verifies that an empty module map
+// compiles successfully using the deny-all fallback.
+func TestCompileModules_EmptyModulesDenyAll(t *testing.T) {
+	_, err := compileModules(context.Background(), store.PolicyTypeEligibility, "data.jitsudo.eligibility.allow", nil)
+	if err != nil {
+		t.Fatalf("expected compile success for empty modules; got: %v", err)
+	}
+}
+
+// TestCompileModules_EmptyApprovalModules verifies the deny-all fallback for
+// the approval policy type.
+func TestCompileModules_EmptyApprovalModules(t *testing.T) {
+	_, err := compileModules(context.Background(), store.PolicyTypeApproval, "data.jitsudo.approval.allow", nil)
+	if err != nil {
+		t.Fatalf("expected compile success for empty approval modules; got: %v", err)
+	}
+}
+
+// TestCompileModules_SyntaxError verifies that a Rego syntax error is caught.
+func TestCompileModules_SyntaxError(t *testing.T) {
+	modules := map[string]string{
+		"bad.rego": "package jitsudo.eligibility\n!!!not valid rego!!!",
+	}
+	_, err := compileModules(context.Background(), store.PolicyTypeEligibility, "data.jitsudo.eligibility.allow", modules)
+	if err == nil {
+		t.Fatal("expected compile error for invalid Rego syntax, got nil")
+	}
+}
+
 // ── EvalEligibility tests ───────────────────────────────────────────────────
 
 // newEngineWithEligibilityPolicy creates an Engine whose eligibilityQuery is


### PR DESCRIPTION
## Summary

- `ApplyPolicy` and `DeletePolicy` previously wrote to the DB first, then called `policy.Reload()`. A Rego compile error during reload returned an error to the caller but the DB mutation had already committed, leaving the store inconsistent with what the caller believed
- Adds `CompileCheck` and `CompileCheckWithout` to `policy.Engine` that simulate the proposed change (add or remove) against the current enabled policy set and attempt OPA compilation **before** any DB write
- `ApplyPolicy` now calls `CompileCheck` first; returns `codes.InvalidArgument` on compile failure without touching the store
- `DeletePolicy` fetches the policy type first, calls `CompileCheckWithout`, and only proceeds with deletion if the remaining set compiles
- Refactors `buildQuery` to delegate to a new `compileModules` pure function, eliminating duplicated OPA option construction

Fixes #18

## Test plan

- [ ] `go test ./internal/server/policy/... ./internal/server/api/...` passes
- [ ] `jitsudo policy apply -f conflict.rego` (with conflicting `default allow := false`) returns `InvalidArgument` error and policy does NOT appear in `jitsudo policy list`
- [ ] `jitsudo policy apply -f valid.rego` continues to work correctly
- [ ] `jitsudo policy delete <id>` of a policy whose removal would leave a non-compiling set returns `InvalidArgument` without deleting the policy
- [ ] `jitsudo policy delete <id>` of a valid policy works correctly