### PR TITLE
feat: MCP agent support

### DIFF
--- a/cmd/jitsudod/serve.go
+++ b/cmd/jitsudod/serve.go
@@ -68,6 +68,7 @@ func runServe(ctx context.Context, configPath string) error {
 		},
 		MCPToken:         cfg.MCP.Token,
 		MCPAgentIdentity: cfg.MCP.AgentIdentity,
+		MCPAgentAddr:     cfg.Server.MCPAgentAddr,
 	}, st)
 
 	if err := srv.Start(ctx); err != nil {

--- a/helm/jitsudo/templates/deployment.yaml
+++ b/helm/jitsudo/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
               value: {{ .Values.config.mcp.token | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.config.mcpAgent.enabled }}
+            - name: JITSUDOD_MCP_AGENT_ADDR
+              value: {{ .Values.config.mcpAgent.addr | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ trimPrefix ":" .Values.config.server.httpAddr | int }}
@@ -84,6 +88,11 @@ spec:
             - name: grpc
               containerPort: {{ trimPrefix ":" .Values.config.server.grpcAddr | int }}
               protocol: TCP
+            {{- if .Values.config.mcpAgent.enabled }}
+            - name: mcp-agent
+              containerPort: {{ trimPrefix ":" .Values.config.mcpAgent.addr | int }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/jitsudo/templates/service.yaml
+++ b/helm/jitsudo/templates/service.yaml
@@ -17,3 +17,9 @@ spec:
       port: {{ .Values.service.grpc.port }}
       targetPort: grpc
       protocol: TCP
+    {{- if .Values.config.mcpAgent.enabled }}
+    - name: mcp-agent
+      port: {{ .Values.service.mcpAgent.port }}
+      targetPort: mcp-agent
+      protocol: TCP
+    {{- end }}

--- a/helm/jitsudo/values.yaml
+++ b/helm/jitsudo/values.yaml
@@ -121,6 +121,15 @@ config:
     # Identity recorded in the audit log for every AI approval decision.
     agentIdentity: "mcp-agent"
 
+  # ── MCP Agent Requestor Interface ───────────────────────────────────────────
+  # Set enabled: true to start the MCP agent-requestor server on port 8081.
+  # AI agents (e.g. Claude Desktop) connect here to call request_access and
+  # receive access/resolved push notifications over SSE.
+  # Authentication uses the same OIDC provider as the main API.
+  mcpAgent:
+    enabled: false
+    addr: ":8081"
+
   log:
     level: "info"
     format: "json"
@@ -133,6 +142,9 @@ service:
   grpc:
     type: ClusterIP
     port: 8443
+  mcpAgent:
+    type: ClusterIP
+    port: 8081
 
 # ── Ingress ───────────────────────────────────────────────────────────────────
 ingress:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,8 +46,9 @@ type MCPCfg struct {
 
 // ServerCfg holds network listener addresses.
 type ServerCfg struct {
-	HTTPAddr string `yaml:"http_addr"`
-	GRPCAddr string `yaml:"grpc_addr"`
+	HTTPAddr     string `yaml:"http_addr"`
+	GRPCAddr     string `yaml:"grpc_addr"`
+	MCPAgentAddr string `yaml:"mcp_agent_addr"`
 }
 
 // DatabaseCfg holds the PostgreSQL connection DSN.
@@ -124,8 +125,9 @@ func Load(path string) (*FileConfig, error) {
 func defaults() *FileConfig {
 	return &FileConfig{
 		Server: ServerCfg{
-			HTTPAddr: ":8080",
-			GRPCAddr: ":8443",
+			HTTPAddr:     ":8080",
+			GRPCAddr:     ":8443",
+			MCPAgentAddr: ":8081",
 		},
 		Database: DatabaseCfg{
 			URL: "postgres://jitsudo:jitsudo@localhost:5432/jitsudo?sslmode=disable",
@@ -146,6 +148,7 @@ func defaults() *FileConfig {
 func applyEnv(cfg *FileConfig) {
 	setIfEnv(&cfg.Server.HTTPAddr, "JITSUDOD_HTTP_ADDR")
 	setIfEnv(&cfg.Server.GRPCAddr, "JITSUDOD_GRPC_ADDR")
+	setIfEnv(&cfg.Server.MCPAgentAddr, "JITSUDOD_MCP_AGENT_ADDR")
 	setIfEnv(&cfg.Database.URL, "JITSUDOD_DATABASE_URL")
 	setIfEnv(&cfg.Auth.OIDCIssuer, "JITSUDOD_OIDC_ISSUER")
 	setIfEnv(&cfg.Auth.OIDCDiscoveryURL, "JITSUDOD_OIDC_DISCOVERY_URL")

--- a/internal/server/auth/auth.go
+++ b/internal/server/auth/auth.go
@@ -27,11 +27,24 @@ type Config struct {
 	ClientID     string // Expected audience claim, e.g. "jitsudo-cli"
 }
 
+// PrincipalType identifies the kind of principal that authenticated.
+// The zero value "" is treated the same as PrincipalTypeHuman by all callers.
+type PrincipalType string
+
+const (
+	// PrincipalTypeHuman is the default for human users authenticating via the CLI or REST API.
+	PrincipalTypeHuman PrincipalType = "human"
+	// PrincipalTypeAgent is set by the MCP agent server after OIDC verification,
+	// marking the request as originating from an AI agent requestor surface.
+	PrincipalTypeAgent PrincipalType = "agent"
+)
+
 // Identity holds the verified claims extracted from an OIDC ID token.
 type Identity struct {
-	Subject string
-	Email   string
-	Groups  []string
+	Subject       string
+	Email         string
+	Groups        []string
+	PrincipalType PrincipalType // set by surface-specific middleware; zero value treated as "human"
 }
 
 // Verifier validates OIDC ID tokens and extracts Identity claims.

--- a/internal/server/mcpagent/auth.go
+++ b/internal/server/mcpagent/auth.go
@@ -1,0 +1,42 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+package mcpagent
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
+)
+
+// authVerifier validates OIDC Bearer tokens and returns the caller's Identity.
+// *auth.Verifier satisfies this interface.
+type authVerifier interface {
+	Verify(ctx context.Context, rawToken string) (*auth.Identity, error)
+}
+
+// authenticate extracts a Bearer token from r, verifies it via v, and sets
+// id.PrincipalType = auth.PrincipalTypeAgent to mark the request as originating
+// from an AI agent requestor surface.
+//
+// Returns the authenticated Identity, or nil if authentication failed (in which
+// case a 401 response has already been written to w).
+func authenticate(w http.ResponseWriter, r *http.Request, v authVerifier) *auth.Identity {
+	raw := r.Header.Get("Authorization")
+	token := strings.TrimPrefix(raw, "Bearer ")
+	if token == raw || token == "" {
+		http.Error(w, "Unauthorized: Bearer token required", http.StatusUnauthorized)
+		return nil
+	}
+
+	id, err := v.Verify(r.Context(), token)
+	if err != nil {
+		http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
+		return nil
+	}
+
+	id.PrincipalType = auth.PrincipalTypeAgent
+	return id
+}

--- a/internal/server/mcpagent/auth.go
+++ b/internal/server/mcpagent/auth.go
@@ -18,11 +18,8 @@ type authVerifier interface {
 }
 
 // authenticate extracts a Bearer token from r, verifies it via v, and sets
-// id.PrincipalType = auth.PrincipalTypeAgent to mark the request as originating
-// from an AI agent requestor surface.
-//
-// Returns the authenticated Identity, or nil if authentication failed (in which
-// case a 401 response has already been written to w).
+// id.PrincipalType = auth.PrincipalTypeAgent. Returns nil and writes a 401 on
+// failure.
 func authenticate(w http.ResponseWriter, r *http.Request, v authVerifier) *auth.Identity {
 	raw := r.Header.Get("Authorization")
 	token := strings.TrimPrefix(raw, "Bearer ")

--- a/internal/server/mcpagent/broker.go
+++ b/internal/server/mcpagent/broker.go
@@ -1,0 +1,143 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+// Package mcpagent implements the MCP agent-as-requestor surface for jitsudod.
+// AI agents connect via MCP-over-SSE on a dedicated port, call request_access,
+// and receive an access/resolved push notification the instant a decision is made.
+package mcpagent
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/jitsudo-dev/jitsudo/internal/server/notifications"
+	"github.com/jitsudo-dev/jitsudo/internal/store"
+)
+
+// brokerStore is the subset of *store.Store used by the Broker.
+type brokerStore interface {
+	GetRequest(ctx context.Context, id string) (*store.RequestRow, error)
+}
+
+// sseEvent is the payload pushed to a waiting SSE subscriber when a request resolves.
+type sseEvent struct {
+	RequestID   string            `json:"request_id"`
+	Outcome     string            `json:"outcome"` // "approved" | "denied" | "expired" | "revoked"
+	State       string            `json:"state"`
+	Credentials map[string]string `json:"credentials,omitempty"`
+	ExpiresAt   *time.Time        `json:"expires_at,omitempty"`
+}
+
+type subscription struct {
+	ch       chan sseEvent
+	identity string
+}
+
+// Broker fans resolution events to waiting SSE connections. It implements
+// notifications.Notifier and is appended to the dispatcher's notifier list
+// so it receives every workflow event.
+type Broker struct {
+	store brokerStore
+	mu    sync.RWMutex
+	subs  map[string][]subscription // key: requestID
+}
+
+// NewBroker creates a Broker backed by s for credential fetches.
+func NewBroker(s brokerStore) *Broker {
+	return &Broker{store: s, subs: make(map[string][]subscription)}
+}
+
+// Subscribe registers a waiter for the given requestID. Returns a read channel
+// (buffered 1) that will receive at most one sseEvent when the request resolves,
+// and an unsubscribe function the caller must defer.
+func (b *Broker) Subscribe(requestID, identity string) (<-chan sseEvent, func()) {
+	ch := make(chan sseEvent, 1)
+	sub := subscription{ch: ch, identity: identity}
+
+	b.mu.Lock()
+	b.subs[requestID] = append(b.subs[requestID], sub)
+	b.mu.Unlock()
+
+	unsub := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		subs := b.subs[requestID]
+		for i, s := range subs {
+			if s.ch == ch {
+				b.subs[requestID] = append(subs[:i], subs[i+1:]...)
+				break
+			}
+		}
+		if len(b.subs[requestID]) == 0 {
+			delete(b.subs, requestID)
+		}
+	}
+	return ch, unsub
+}
+
+// Notify implements notifications.Notifier. It is called by the dispatcher
+// (in its own goroutine with a 10s deadline) for every workflow event.
+// For resolution events it fetches the current row (for credentials) and
+// delivers to any waiting subscribers.
+func (b *Broker) Notify(ctx context.Context, event notifications.Event) error {
+	outcome := outcomeFor(event.Type)
+	if outcome == "" {
+		return nil // not a resolution event — nothing to push
+	}
+
+	b.mu.RLock()
+	subs := b.subs[event.RequestID]
+	if len(subs) == 0 {
+		b.mu.RUnlock()
+		return nil
+	}
+	// Copy slice so we can release the lock before fetching from store.
+	targets := make([]subscription, len(subs))
+	copy(targets, subs)
+	b.mu.RUnlock()
+
+	// Fetch the full row so we can include credentials for approved requests.
+	req, err := b.store.GetRequest(ctx, event.RequestID)
+	if err != nil {
+		// Best-effort: send a minimal event without credentials rather than blocking.
+		req = &store.RequestRow{ID: event.RequestID}
+	}
+
+	ev := sseEvent{
+		RequestID: event.RequestID,
+		Outcome:   outcome,
+		State:     string(req.State),
+		ExpiresAt: req.ExpiresAt,
+	}
+	if outcome == "approved" {
+		ev.Credentials = req.CredentialsJSON
+	}
+
+	for _, sub := range targets {
+		select {
+		case sub.ch <- ev:
+		default:
+			// Channel full — subscriber is slow or gone; drop the event.
+			// The SSE handler will detect client disconnect via ctx.Done.
+		}
+	}
+	return nil
+}
+
+// outcomeFor maps a workflow EventType to the SSE outcome string.
+// Returns "" for non-resolution events.
+func outcomeFor(t notifications.EventType) string {
+	switch t {
+	case notifications.EventApproved, notifications.EventAutoApproved, notifications.EventAIApproved:
+		return "approved"
+	case notifications.EventDenied, notifications.EventAIDenied:
+		return "denied"
+	case notifications.EventExpired:
+		return "expired"
+	case notifications.EventRevoked:
+		return "revoked"
+	default:
+		return ""
+	}
+}

--- a/internal/server/mcpagent/broker.go
+++ b/internal/server/mcpagent/broker.go
@@ -76,10 +76,8 @@ func (b *Broker) Subscribe(requestID, identity string) (<-chan sseEvent, func())
 	return ch, unsub
 }
 
-// Notify implements notifications.Notifier. It is called by the dispatcher
-// (in its own goroutine with a 10s deadline) for every workflow event.
-// For resolution events it fetches the current row (for credentials) and
-// delivers to any waiting subscribers.
+// Notify implements notifications.Notifier. For resolution events it fetches
+// the current row (for credentials) and delivers to any waiting subscribers.
 func (b *Broker) Notify(ctx context.Context, event notifications.Event) error {
 	outcome := outcomeFor(event.Type)
 	if outcome == "" {

--- a/internal/server/mcpagent/mcpagent_test.go
+++ b/internal/server/mcpagent/mcpagent_test.go
@@ -1,0 +1,750 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+package mcpagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
+	"github.com/jitsudo-dev/jitsudo/internal/server/notifications"
+	"github.com/jitsudo-dev/jitsudo/internal/server/workflow"
+	"github.com/jitsudo-dev/jitsudo/internal/store"
+)
+
+// ── Stubs ─────────────────────────────────────────────────────────────────────
+
+type stubVerifier struct {
+	identity *auth.Identity
+	err      error
+}
+
+func (v *stubVerifier) Verify(_ context.Context, _ string) (*auth.Identity, error) {
+	if v.err != nil {
+		return nil, v.err
+	}
+	cp := *v.identity
+	return &cp, nil
+}
+
+type stubWorkflow struct {
+	createResult *store.RequestRow
+	createErr    error
+	revokeResult *store.RequestRow
+	revokeErr    error
+}
+
+func (w *stubWorkflow) CreateMCPRequest(_ context.Context, _ *auth.Identity, _ workflow.MCPRequestInput) (*store.RequestRow, error) {
+	return w.createResult, w.createErr
+}
+
+func (w *stubWorkflow) RevokeRequest(_ context.Context, _ *auth.Identity, _ string, _ string) (*store.RequestRow, error) {
+	return w.revokeResult, w.revokeErr
+}
+
+type stubAgentStore struct {
+	row       *store.RequestRow
+	getErr    error
+	grants    []*store.RequestRow
+	grantsErr error
+}
+
+func (s *stubAgentStore) GetRequest(_ context.Context, _ string) (*store.RequestRow, error) {
+	return s.row, s.getErr
+}
+
+func (s *stubAgentStore) ListActiveGrantsByIdentity(_ context.Context, _ string) ([]*store.RequestRow, error) {
+	return s.grants, s.grantsErr
+}
+
+type stubBrokerStore struct {
+	row *store.RequestRow
+	err error
+}
+
+func (s *stubBrokerStore) GetRequest(_ context.Context, _ string) (*store.RequestRow, error) {
+	return s.row, s.err
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func okVerifier() *stubVerifier {
+	return &stubVerifier{identity: &auth.Identity{Email: "agent@example.com", Subject: "sub-agent"}}
+}
+
+func newTestServer(wf agentWorkflow, s agentStore, v authVerifier) *Server {
+	broker := NewBroker(&stubBrokerStore{row: &store.RequestRow{}})
+	return New(wf, s, v, broker)
+}
+
+// rpcBody builds a JSON-RPC 2.0 POST body. id may be nil for notification.
+func rpcBody(id any, method string, params any) *bytes.Buffer {
+	m := map[string]any{"jsonrpc": "2.0", "method": method}
+	if id != nil {
+		m["id"] = id
+	}
+	if params != nil {
+		m["params"] = params
+	}
+	b, _ := json.Marshal(m)
+	return bytes.NewBuffer(b)
+}
+
+func postMessages(srv *Server, v authVerifier, body *bytes.Buffer) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/mcp/agent/messages", body)
+	if v != nil {
+		req.Header.Set("Authorization", "Bearer valid-token")
+	}
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func decodeRPCResponse(t *testing.T, w *httptest.ResponseRecorder) rpcResponse {
+	t.Helper()
+	var resp rpcResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode rpcResponse: %v", err)
+	}
+	return resp
+}
+
+// ── authenticate ──────────────────────────────────────────────────────────────
+
+func TestAuthenticate_MissingHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	w := httptest.NewRecorder()
+	id := authenticate(w, req, okVerifier())
+	if id != nil {
+		t.Error("expected nil identity for missing Authorization header")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestAuthenticate_NoBearerPrefix(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Token abc123")
+	w := httptest.NewRecorder()
+	id := authenticate(w, req, okVerifier())
+	if id != nil {
+		t.Error("expected nil identity for non-Bearer token")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestAuthenticate_VerifyError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+	v := &stubVerifier{err: errors.New("token expired")}
+	id := authenticate(w, req, v)
+	if id != nil {
+		t.Error("expected nil identity on verify error")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestAuthenticate_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer good-token")
+	w := httptest.NewRecorder()
+	id := authenticate(w, req, okVerifier())
+	if id == nil {
+		t.Fatal("expected non-nil identity")
+	}
+	if id.Email != "agent@example.com" {
+		t.Errorf("Email = %q, want %q", id.Email, "agent@example.com")
+	}
+	if id.PrincipalType != auth.PrincipalTypeAgent {
+		t.Errorf("PrincipalType = %q, want %q", id.PrincipalType, auth.PrincipalTypeAgent)
+	}
+}
+
+// ── handleMessages ────────────────────────────────────────────────────────────
+
+func TestHandleMessages_MethodNotAllowed(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	req := httptest.NewRequest(http.MethodGet, "/mcp/agent/messages", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleMessages_AuthFailure(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, &stubVerifier{err: errors.New("bad")})
+	req := httptest.NewRequest(http.MethodPost, "/mcp/agent/messages", rpcBody(1, "initialize", nil))
+	req.Header.Set("Authorization", "Bearer bad")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleMessages_InvalidJSON(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	w := postMessages(srv, okVerifier(), bytes.NewBufferString("{bad json"))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeParse {
+		t.Errorf("want errCodeParse (%d), got %v", errCodeParse, resp.Error)
+	}
+}
+
+func TestHandleMessages_BadVersion(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "1.0", "id": 1, "method": "initialize"})
+	w := postMessages(srv, okVerifier(), bytes.NewBuffer(body))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeInvalidReq {
+		t.Errorf("want errCodeInvalidReq (%d), got %v", errCodeInvalidReq, resp.Error)
+	}
+}
+
+func TestHandleMessages_Notification(t *testing.T) {
+	// Notifications have null id — server must return 202 with no body.
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp/agent/messages", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want 202", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body, got %q", w.Body.String())
+	}
+}
+
+func TestHandleMessages_Initialize(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	w := postMessages(srv, okVerifier(), rpcBody(1, "initialize", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result initializeResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ServerInfo.Name != "jitsudo-mcp-agent" {
+		t.Errorf("ServerInfo.Name = %q, want %q", result.ServerInfo.Name, "jitsudo-mcp-agent")
+	}
+	if result.Capabilities.Tools == nil {
+		t.Error("expected non-nil Capabilities.Tools")
+	}
+}
+
+func TestHandleMessages_ToolsList(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	w := postMessages(srv, okVerifier(), rpcBody(1, "tools/list", nil))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result toolsListResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Tools) != 3 {
+		t.Errorf("len(Tools) = %d, want 3", len(result.Tools))
+	}
+}
+
+func TestHandleMessages_UnknownMethod(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	w := postMessages(srv, okVerifier(), rpcBody(1, "foo/bar", nil))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeMethodUnknown {
+		t.Errorf("want errCodeMethodUnknown (%d), got %v", errCodeMethodUnknown, resp.Error)
+	}
+}
+
+// ── toolRequestAccess ─────────────────────────────────────────────────────────
+
+func toolsCallBody(id any, toolName string, args map[string]any) *bytes.Buffer {
+	return rpcBody(id, "tools/call", map[string]any{"name": toolName, "arguments": args})
+}
+
+func TestToolRequestAccess_MissingRequiredArg(t *testing.T) {
+	fullArgs := map[string]any{
+		"action":           "s3:GetObject",
+		"resource":         "arn:aws:s3:::my-bucket/*",
+		"reason":           "need data",
+		"duration_seconds": 3600.0,
+	}
+	for _, missing := range []string{"action", "resource", "reason", "duration_seconds"} {
+		t.Run("missing_"+missing, func(t *testing.T) {
+			args := make(map[string]any, len(fullArgs))
+			for k, v := range fullArgs {
+				if k != missing {
+					args[k] = v
+				}
+			}
+			srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+			w := postMessages(srv, okVerifier(), toolsCallBody(1, "request_access", args))
+			resp := decodeRPCResponse(t, w)
+			if resp.Error == nil || resp.Error.Code != errCodeInvalidParams {
+				t.Errorf("want errCodeInvalidParams (%d) for missing %q, got %v", errCodeInvalidParams, missing, resp.Error)
+			}
+		})
+	}
+}
+
+func TestToolRequestAccess_WorkflowError(t *testing.T) {
+	wf := &stubWorkflow{createErr: errors.New("policy denied")}
+	srv := newTestServer(wf, &stubAgentStore{}, okVerifier())
+	args := map[string]any{"action": "s3:Get", "resource": "arn:aws:s3:::b", "reason": "r", "duration_seconds": 3600.0}
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "request_access", args))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeInternal {
+		t.Errorf("want errCodeInternal (%d), got %v", errCodeInternal, resp.Error)
+	}
+}
+
+func TestToolRequestAccess_Pending(t *testing.T) {
+	now := time.Now().UTC()
+	wf := &stubWorkflow{createResult: &store.RequestRow{
+		ID: "req_001", State: store.StatePending, CreatedAt: now, UpdatedAt: now,
+	}}
+	srv := newTestServer(wf, &stubAgentStore{}, okVerifier())
+	args := map[string]any{"action": "s3:Get", "resource": "arn:aws:s3:::b", "reason": "r", "duration_seconds": 3600.0}
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "request_access", args))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result toolCallResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["status"] != "pending" {
+		t.Errorf("status = %q, want %q", payload["status"], "pending")
+	}
+	if payload["request_id"] != "req_001" {
+		t.Errorf("request_id = %q, want %q", payload["request_id"], "req_001")
+	}
+}
+
+func TestToolRequestAccess_AutoApproved(t *testing.T) {
+	now := time.Now().UTC()
+	exp := now.Add(time.Hour)
+	wf := &stubWorkflow{createResult: &store.RequestRow{
+		ID:              "req_002",
+		State:           store.StateActive,
+		CredentialsJSON: map[string]string{"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE"},
+		ExpiresAt:       &exp,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}}
+	srv := newTestServer(wf, &stubAgentStore{}, okVerifier())
+	args := map[string]any{"action": "s3:Get", "resource": "arn:aws:s3:::b", "reason": "r", "duration_seconds": 3600.0}
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "request_access", args))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result toolCallResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["status"] != "active" {
+		t.Errorf("status = %q, want %q", payload["status"], "active")
+	}
+	if payload["credentials"] == nil {
+		t.Error("expected credentials in auto-approved response")
+	}
+	if payload["expires_at"] == nil {
+		t.Error("expected expires_at in auto-approved response")
+	}
+}
+
+// ── toolListMyActiveGrants ────────────────────────────────────────────────────
+
+func TestToolListMyActiveGrants_Empty(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{grants: nil}, okVerifier())
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "list_my_active_grants", map[string]any{}))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result toolCallResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &items); err != nil {
+		t.Fatalf("unmarshal items: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected empty list, got %d items", len(items))
+	}
+}
+
+func TestToolListMyActiveGrants_WithGrants(t *testing.T) {
+	now := time.Now().UTC()
+	exp := now.Add(time.Hour)
+	grants := []*store.RequestRow{
+		{ID: "req_a", Provider: "aws", Role: "readonly", ResourceScope: "123456789012", ExpiresAt: &exp},
+		{ID: "req_b", Provider: "gcp", Role: "viewer", ResourceScope: "my-project"},
+	}
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{grants: grants}, okVerifier())
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "list_my_active_grants", map[string]any{}))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result toolCallResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &items); err != nil {
+		t.Fatalf("unmarshal items: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0]["id"] != "req_a" {
+		t.Errorf("items[0].id = %v, want req_a", items[0]["id"])
+	}
+	if items[0]["expires_at"] == nil {
+		t.Error("expected expires_at on req_a")
+	}
+	if items[1]["id"] != "req_b" {
+		t.Errorf("items[1].id = %v, want req_b", items[1]["id"])
+	}
+	if _, hasExp := items[1]["expires_at"]; hasExp {
+		t.Error("expected no expires_at on req_b (nil ExpiresAt)")
+	}
+}
+
+func TestToolListMyActiveGrants_StoreError(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{grantsErr: errors.New("db down")}, okVerifier())
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "list_my_active_grants", map[string]any{}))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeInternal {
+		t.Errorf("want errCodeInternal (%d), got %v", errCodeInternal, resp.Error)
+	}
+}
+
+// ── toolRevokeAccess ──────────────────────────────────────────────────────────
+
+func TestToolRevokeAccess_MissingRequestID(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "revoke_access", map[string]any{}))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeInvalidParams {
+		t.Errorf("want errCodeInvalidParams (%d), got %v", errCodeInvalidParams, resp.Error)
+	}
+}
+
+func TestToolRevokeAccess_Success(t *testing.T) {
+	now := time.Now().UTC()
+	wf := &stubWorkflow{revokeResult: &store.RequestRow{
+		ID: "req_001", State: store.StateRevoked, CreatedAt: now, UpdatedAt: now,
+	}}
+	srv := newTestServer(wf, &stubAgentStore{}, okVerifier())
+	args := map[string]any{"request_id": "req_001", "reason": "done early"}
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "revoke_access", args))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var result toolCallResult
+	if err := json.Unmarshal(b, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["status"] != "revoked" {
+		t.Errorf("status = %q, want %q", payload["status"], "revoked")
+	}
+}
+
+func TestToolRevokeAccess_WorkflowError(t *testing.T) {
+	wf := &stubWorkflow{revokeErr: errors.New("not found")}
+	srv := newTestServer(wf, &stubAgentStore{}, okVerifier())
+	args := map[string]any{"request_id": "req_missing"}
+	w := postMessages(srv, okVerifier(), toolsCallBody(1, "revoke_access", args))
+	resp := decodeRPCResponse(t, w)
+	if resp.Error == nil || resp.Error.Code != errCodeInternal {
+		t.Errorf("want errCodeInternal (%d), got %v", errCodeInternal, resp.Error)
+	}
+}
+
+// ── handleSSE ─────────────────────────────────────────────────────────────────
+
+func sseRequest(method, requestID string, v *stubVerifier) *http.Request {
+	target := "/mcp/agent/sse"
+	if requestID != "" {
+		target = fmt.Sprintf("/mcp/agent/sse?request_id=%s", requestID)
+	}
+	req := httptest.NewRequest(method, target, nil)
+	if v != nil {
+		req.Header.Set("Authorization", "Bearer valid-token")
+	}
+	return req
+}
+
+func TestHandleSSE_MethodNotAllowed(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	req := sseRequest(http.MethodPost, "req_001", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandleSSE_AuthFailure(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, &stubVerifier{err: errors.New("bad")})
+	req := sseRequest(http.MethodGet, "req_001", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleSSE_MissingRequestID(t *testing.T) {
+	srv := newTestServer(&stubWorkflow{}, &stubAgentStore{}, okVerifier())
+	req := sseRequest(http.MethodGet, "", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleSSE_RequestNotFound(t *testing.T) {
+	s := &stubAgentStore{getErr: store.ErrNotFound}
+	srv := newTestServer(&stubWorkflow{}, s, okVerifier())
+	req := sseRequest(http.MethodGet, "req_missing", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleSSE_Forbidden(t *testing.T) {
+	s := &stubAgentStore{row: &store.RequestRow{
+		ID:                "req_001",
+		State:             store.StatePending,
+		RequesterIdentity: "other@example.com", // different from agent@example.com
+	}}
+	srv := newTestServer(&stubWorkflow{}, s, okVerifier())
+	req := sseRequest(http.MethodGet, "req_001", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestHandleSSE_AlreadyActive(t *testing.T) {
+	creds := map[string]string{"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE"}
+	s := &stubAgentStore{row: &store.RequestRow{
+		ID:                "req_001",
+		State:             store.StateActive,
+		RequesterIdentity: "agent@example.com",
+		CredentialsJSON:   creds,
+	}}
+	srv := newTestServer(&stubWorkflow{}, s, okVerifier())
+	req := sseRequest(http.MethodGet, "req_001", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Result().Header.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", w.Result().Header.Get("Content-Type"))
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "event: access/resolved") {
+		t.Errorf("expected SSE event in body, got: %q", body)
+	}
+	if !strings.Contains(body, `"outcome":"approved"`) {
+		t.Errorf("expected outcome=approved in body, got: %q", body)
+	}
+	if !strings.Contains(body, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("expected credentials in body, got: %q", body)
+	}
+}
+
+func TestHandleSSE_AlreadyRejected(t *testing.T) {
+	s := &stubAgentStore{row: &store.RequestRow{
+		ID:                "req_002",
+		State:             store.StateRejected,
+		RequesterIdentity: "agent@example.com",
+	}}
+	srv := newTestServer(&stubWorkflow{}, s, okVerifier())
+	req := sseRequest(http.MethodGet, "req_002", okVerifier())
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, `"outcome":"denied"`) {
+		t.Errorf("expected outcome=denied in body, got: %q", body)
+	}
+}
+
+// ── Broker ────────────────────────────────────────────────────────────────────
+
+func TestBrokerSubscribe_ChannelBuffered(t *testing.T) {
+	b := NewBroker(&stubBrokerStore{})
+	ch, unsub := b.Subscribe("req_001", "agent@example.com")
+	defer unsub()
+	if cap(ch) != 1 {
+		t.Errorf("channel cap = %d, want 1", cap(ch))
+	}
+}
+
+func TestBrokerSubscribe_Unsubscribe(t *testing.T) {
+	b := NewBroker(&stubBrokerStore{})
+	_, unsub := b.Subscribe("req_001", "agent@example.com")
+	unsub()
+
+	b.mu.RLock()
+	_, exists := b.subs["req_001"]
+	b.mu.RUnlock()
+	if exists {
+		t.Error("expected requestID to be removed from subs map after unsubscribe")
+	}
+}
+
+func TestBrokerNotify_NonResolutionEvent(t *testing.T) {
+	b := NewBroker(&stubBrokerStore{row: &store.RequestRow{ID: "req_001"}})
+	ch, unsub := b.Subscribe("req_001", "agent@example.com")
+	defer unsub()
+
+	_ = b.Notify(context.Background(), notifications.Event{
+		Type:      notifications.EventRequestCreated,
+		RequestID: "req_001",
+	})
+
+	select {
+	case ev := <-ch:
+		t.Errorf("expected no event for non-resolution type, got %v", ev)
+	default:
+		// correct: channel is empty
+	}
+}
+
+func TestBrokerNotify_Approved(t *testing.T) {
+	creds := map[string]string{"token": "abc"}
+	bs := &stubBrokerStore{row: &store.RequestRow{
+		ID:              "req_001",
+		State:           store.StateActive,
+		CredentialsJSON: creds,
+	}}
+	b := NewBroker(bs)
+	ch, unsub := b.Subscribe("req_001", "agent@example.com")
+	defer unsub()
+
+	_ = b.Notify(context.Background(), notifications.Event{
+		Type:      notifications.EventApproved,
+		RequestID: "req_001",
+	})
+
+	select {
+	case ev := <-ch:
+		if ev.Outcome != "approved" {
+			t.Errorf("Outcome = %q, want approved", ev.Outcome)
+		}
+		if ev.Credentials["token"] != "abc" {
+			t.Errorf("Credentials = %v, want token=abc", ev.Credentials)
+		}
+	default:
+		t.Error("expected event on channel, got nothing")
+	}
+}
+
+func TestBrokerNotify_Denied(t *testing.T) {
+	bs := &stubBrokerStore{row: &store.RequestRow{ID: "req_002", State: store.StateRejected}}
+	b := NewBroker(bs)
+	ch, unsub := b.Subscribe("req_002", "agent@example.com")
+	defer unsub()
+
+	_ = b.Notify(context.Background(), notifications.Event{
+		Type:      notifications.EventDenied,
+		RequestID: "req_002",
+	})
+
+	select {
+	case ev := <-ch:
+		if ev.Outcome != "denied" {
+			t.Errorf("Outcome = %q, want denied", ev.Outcome)
+		}
+		if len(ev.Credentials) != 0 {
+			t.Errorf("expected no credentials for denied, got %v", ev.Credentials)
+		}
+	default:
+		t.Error("expected event on channel, got nothing")
+	}
+}
+
+func TestBrokerNotify_StoreError(t *testing.T) {
+	bs := &stubBrokerStore{err: errors.New("db down")}
+	b := NewBroker(bs)
+	ch, unsub := b.Subscribe("req_003", "agent@example.com")
+	defer unsub()
+
+	// Must not panic; must still deliver a minimal event.
+	_ = b.Notify(context.Background(), notifications.Event{
+		Type:      notifications.EventApproved,
+		RequestID: "req_003",
+	})
+
+	select {
+	case ev := <-ch:
+		if ev.Outcome != "approved" {
+			t.Errorf("Outcome = %q, want approved", ev.Outcome)
+		}
+		// Credentials should be nil/empty since the store fetch failed.
+		if len(ev.Credentials) != 0 {
+			t.Errorf("expected no credentials after store error, got %v", ev.Credentials)
+		}
+	default:
+		t.Error("expected minimal event even on store error")
+	}
+}

--- a/internal/server/mcpagent/server.go
+++ b/internal/server/mcpagent/server.go
@@ -1,0 +1,251 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+package mcpagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
+	"github.com/jitsudo-dev/jitsudo/internal/server/notifications"
+	"github.com/jitsudo-dev/jitsudo/internal/store"
+)
+
+// Server is the MCP agent-requestor HTTP server. It exposes:
+//
+//	POST /mcp/agent/messages  — JSON-RPC 2.0 tool endpoint
+//	GET  /mcp/agent/sse       — SSE stream for access/resolved push notifications
+type Server struct {
+	workflow agentWorkflow
+	store    agentStore
+	verifier authVerifier
+	broker   *Broker
+}
+
+// New creates a Server. All parameters are required.
+func New(wf agentWorkflow, s agentStore, v authVerifier, b *Broker) *Server {
+	return &Server{workflow: wf, store: s, verifier: v, broker: b}
+}
+
+// Handler returns an http.Handler with the two routes registered.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp/agent/messages", s.handleMessages)
+	mux.HandleFunc("/mcp/agent/sse", s.handleSSE)
+	return mux
+}
+
+// ─── POST /mcp/agent/messages ─────────────────────────────────────────────
+
+func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	identity := authenticate(w, r, s.verifier)
+	if identity == nil {
+		return
+	}
+
+	var req rpcRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, nil, errCodeParse, "parse error: "+err.Error())
+		return
+	}
+	if req.JSONRPC != "2.0" {
+		s.writeError(w, req.ID, errCodeInvalidReq, `jsonrpc must be "2.0"`)
+		return
+	}
+
+	// Notifications have no id and require no response.
+	if req.ID == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	result, rErr := s.dispatchRPC(r.Context(), identity, req)
+	if rErr != nil {
+		s.writeError(w, req.ID, rErr.Code, rErr.Message)
+		return
+	}
+
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Warn().Err(err).Msg("mcpagent: encode response")
+	}
+}
+
+func (s *Server) dispatchRPC(ctx context.Context, identity *auth.Identity, req rpcRequest) (any, *rpcError) {
+	switch req.Method {
+	case "initialize":
+		return initializeResult{
+			ProtocolVersion: "2025-03-26",
+			ServerInfo:      serverInfo{Name: "jitsudo-mcp-agent", Version: "1.0"},
+			Capabilities:    capabilities{Tools: &struct{}{}},
+		}, nil
+
+	case "tools/list":
+		return toolsListResult{Tools: allTools()}, nil
+
+	case "tools/call":
+		var p struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return nil, &rpcError{Code: errCodeInvalidParams, Message: "invalid params: " + err.Error()}
+		}
+		switch p.Name {
+		case "request_access":
+			return s.toolRequestAccess(ctx, identity, p.Arguments)
+		case "list_my_active_grants":
+			return s.toolListMyActiveGrants(ctx, identity)
+		case "revoke_access":
+			return s.toolRevokeAccess(ctx, identity, p.Arguments)
+		default:
+			return nil, &rpcError{Code: errCodeMethodUnknown, Message: fmt.Sprintf("unknown tool: %s", p.Name)}
+		}
+
+	default:
+		return nil, &rpcError{Code: errCodeMethodUnknown, Message: fmt.Sprintf("method not found: %s", req.Method)}
+	}
+}
+
+func (s *Server) writeError(w http.ResponseWriter, id json.RawMessage, code int, msg string) {
+	resp := rpcResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: msg}}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// ─── GET /mcp/agent/sse ───────────────────────────────────────────────────
+
+func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	identity := authenticate(w, r, s.verifier)
+	if identity == nil {
+		return
+	}
+
+	requestID := r.URL.Query().Get("request_id")
+	if requestID == "" {
+		http.Error(w, "request_id query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	req, err := s.store.GetRequest(r.Context(), requestID)
+	if err != nil {
+		http.Error(w, "request not found", http.StatusNotFound)
+		return
+	}
+	if req.RequesterIdentity != identity.Email {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Already resolved — push the event immediately and close.
+	if isResolved(req.State) {
+		s.writeResolvedSSE(w, req)
+		return
+	}
+
+	// Set SSE headers before subscribing so the client sees them immediately.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, canFlush := w.(http.Flusher)
+	if canFlush {
+		flusher.Flush()
+	}
+
+	ch, unsub := s.broker.Subscribe(requestID, identity.Email)
+	defer unsub()
+
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+
+		case <-ticker.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			if canFlush {
+				flusher.Flush()
+			}
+
+		case ev := <-ch:
+			data, _ := json.Marshal(ev)
+			fmt.Fprintf(w, "event: access/resolved\ndata: %s\n\n", data)
+			if canFlush {
+				flusher.Flush()
+			}
+			return
+		}
+	}
+}
+
+// writeResolvedSSE writes a single access/resolved SSE event for an already-
+// terminal request and sets the appropriate response headers.
+func (s *Server) writeResolvedSSE(w http.ResponseWriter, req *store.RequestRow) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ev := sseEvent{
+		RequestID: req.ID,
+		Outcome:   outcomeFor(eventTypeForState(req.State)),
+		State:     string(req.State),
+		ExpiresAt: req.ExpiresAt,
+	}
+	if req.State == store.StateActive {
+		ev.Credentials = req.CredentialsJSON
+	}
+
+	data, _ := json.Marshal(ev)
+	fmt.Fprintf(w, "event: access/resolved\ndata: %s\n\n", data)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// isResolved returns true for terminal states where no further approval action
+// is possible and the SSE response can be sent immediately.
+func isResolved(state store.RequestState) bool {
+	switch state {
+	case store.StateActive, store.StateRejected, store.StateExpired, store.StateRevoked:
+		return true
+	}
+	return false
+}
+
+// eventTypeForState maps a terminal request state to the notification EventType
+// so writeResolvedSSE can reuse outcomeFor.
+func eventTypeForState(state store.RequestState) notifications.EventType {
+	switch state {
+	case store.StateActive:
+		return notifications.EventApproved
+	case store.StateRejected:
+		return notifications.EventDenied
+	case store.StateExpired:
+		return notifications.EventExpired
+	case store.StateRevoked:
+		return notifications.EventRevoked
+	}
+	return ""
+}

--- a/internal/server/mcpagent/tools.go
+++ b/internal/server/mcpagent/tools.go
@@ -1,0 +1,277 @@
+// Copyright © 2026 Yu Technology Group, LLC d/b/a jitsudo
+// SPDX-License-Identifier: Elastic-2.0
+
+package mcpagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
+	"github.com/jitsudo-dev/jitsudo/internal/server/workflow"
+	"github.com/jitsudo-dev/jitsudo/internal/store"
+)
+
+// agentWorkflow is the subset of *workflow.Engine used by the tool handlers.
+type agentWorkflow interface {
+	CreateMCPRequest(ctx context.Context, identity *auth.Identity, input workflow.MCPRequestInput) (*store.RequestRow, error)
+	RevokeRequest(ctx context.Context, actor *auth.Identity, requestID, reason string) (*store.RequestRow, error)
+}
+
+// agentStore is the subset of *store.Store used by the tool handlers.
+type agentStore interface {
+	GetRequest(ctx context.Context, id string) (*store.RequestRow, error)
+	ListActiveGrantsByIdentity(ctx context.Context, identity string) ([]*store.RequestRow, error)
+}
+
+// ─── JSON-RPC 2.0 types ────────────────────────────────────────────────────
+// Copied from internal/server/mcp/mcp.go to avoid cross-package coupling.
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+const (
+	errCodeParse         = -32700
+	errCodeInvalidReq    = -32600
+	errCodeMethodUnknown = -32601
+	errCodeInvalidParams = -32602
+	errCodeInternal      = -32603
+)
+
+// ─── MCP protocol types ────────────────────────────────────────────────────
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type capabilities struct {
+	Tools *struct{} `json:"tools,omitempty"`
+}
+
+type initializeResult struct {
+	ProtocolVersion string       `json:"protocolVersion"`
+	ServerInfo      serverInfo   `json:"serverInfo"`
+	Capabilities    capabilities `json:"capabilities"`
+}
+
+type toolDef struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type toolsListResult struct {
+	Tools []toolDef `json:"tools"`
+}
+
+type toolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type toolCallResult struct {
+	Content []toolContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+// ─── Tool implementations ──────────────────────────────────────────────────
+
+func (s *Server) toolRequestAccess(ctx context.Context, identity *auth.Identity, args map[string]any) (any, *rpcError) {
+	action, ok := stringArg(args, "action")
+	if !ok {
+		return nil, &rpcError{Code: errCodeInvalidParams, Message: "action is required"}
+	}
+	resource, ok := stringArg(args, "resource")
+	if !ok {
+		return nil, &rpcError{Code: errCodeInvalidParams, Message: "resource is required"}
+	}
+	reason, ok := stringArg(args, "reason")
+	if !ok {
+		return nil, &rpcError{Code: errCodeInvalidParams, Message: "reason is required"}
+	}
+	durationSeconds, ok := int64Arg(args, "duration_seconds")
+	if !ok {
+		return nil, &rpcError{Code: errCodeInvalidParams, Message: "duration_seconds is required and must be a number"}
+	}
+	ticketRef, _ := stringArg(args, "ticket_ref")
+
+	req, err := s.workflow.CreateMCPRequest(ctx, identity, workflow.MCPRequestInput{
+		Action:          action,
+		Resource:        resource,
+		DurationSeconds: durationSeconds,
+		Reason:          reason,
+		TicketRef:       ticketRef,
+	})
+	if err != nil {
+		return nil, &rpcError{Code: errCodeInternal, Message: err.Error()}
+	}
+
+	var payload map[string]any
+	if req.State == store.StateActive {
+		// Auto-approved: return credentials immediately.
+		payload = map[string]any{
+			"status":      "active",
+			"request_id":  req.ID,
+			"credentials": req.CredentialsJSON,
+		}
+		if req.ExpiresAt != nil {
+			payload["expires_at"] = req.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+	} else {
+		payload = map[string]any{
+			"status":     "pending",
+			"request_id": req.ID,
+			"message":    fmt.Sprintf("Request is pending approval. Open GET /mcp/agent/sse?request_id=%s to wait for the resolution notification.", req.ID),
+		}
+	}
+
+	txt, _ := json.Marshal(payload)
+	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(txt)}}}, nil
+}
+
+func (s *Server) toolListMyActiveGrants(ctx context.Context, identity *auth.Identity) (any, *rpcError) {
+	grants, err := s.store.ListActiveGrantsByIdentity(ctx, identity.Email)
+	if err != nil {
+		return nil, &rpcError{Code: errCodeInternal, Message: err.Error()}
+	}
+
+	type grantSummary struct {
+		ID            string `json:"id"`
+		Provider      string `json:"provider"`
+		Role          string `json:"role"`
+		ResourceScope string `json:"resource_scope"`
+		ExpiresAt     string `json:"expires_at,omitempty"`
+	}
+	items := make([]grantSummary, 0, len(grants))
+	for _, g := range grants {
+		s := grantSummary{
+			ID:            g.ID,
+			Provider:      g.Provider,
+			Role:          g.Role,
+			ResourceScope: g.ResourceScope,
+		}
+		if g.ExpiresAt != nil {
+			s.ExpiresAt = g.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		items = append(items, s)
+	}
+
+	txt, _ := json.Marshal(items)
+	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(txt)}}}, nil
+}
+
+func (s *Server) toolRevokeAccess(ctx context.Context, identity *auth.Identity, args map[string]any) (any, *rpcError) {
+	requestID, ok := stringArg(args, "request_id")
+	if !ok {
+		return nil, &rpcError{Code: errCodeInvalidParams, Message: "request_id is required"}
+	}
+	reason, _ := stringArg(args, "reason")
+
+	req, err := s.workflow.RevokeRequest(ctx, identity, requestID, reason)
+	if err != nil {
+		return nil, &rpcError{Code: errCodeInternal, Message: err.Error()}
+	}
+
+	txt, _ := json.Marshal(map[string]string{
+		"status":     "revoked",
+		"request_id": req.ID,
+		"state":      string(req.State),
+	})
+	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(txt)}}}, nil
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+func stringArg(args map[string]any, key string) (string, bool) {
+	v, ok := args[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// int64Arg extracts an integer argument from a JSON-decoded map.
+// JSON numbers decode as float64, so we accept both float64 and int64.
+func int64Arg(args map[string]any, key string) (int64, bool) {
+	v, ok := args[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
+}
+
+// ─── Tool schema definitions ───────────────────────────────────────────────
+
+func allTools() []toolDef {
+	strProp := func(desc string) map[string]any {
+		return map[string]any{"type": "string", "description": desc}
+	}
+	numProp := func(desc string) map[string]any {
+		return map[string]any{"type": "number", "description": desc}
+	}
+
+	return []toolDef{
+		{
+			Name:        "request_access",
+			Description: "Request temporary elevated access to a resource. Returns immediately with a request_id. If auto-approved, credentials are included in the response. Otherwise open the SSE stream to wait for approval.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"action":           strProp("The action to perform (e.g. \"s3:GetObject\", \"sts:AssumeRole\")"),
+					"resource":         strProp("The resource ARN or identifier (e.g. \"arn:aws:s3:::my-bucket/*\")"),
+					"duration_seconds": numProp("How long the access should last in seconds"),
+					"reason":           strProp("Justification for the access request"),
+					"ticket_ref":       strProp("Optional incident or ticket reference (e.g. \"INC-1234\")"),
+				},
+				"required": []string{"action", "resource", "duration_seconds", "reason"},
+			},
+		},
+		{
+			Name:        "list_my_active_grants",
+			Description: "List all currently active (ACTIVE state) access grants for the authenticated identity.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "revoke_access",
+			Description: "Revoke an active access grant before it expires. Only the original requester may revoke their own grant.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"request_id": strProp("The request ID to revoke (e.g. \"req_01J8KZ...\")"),
+					"reason":     strProp("Optional reason for revoking early"),
+				},
+				"required": []string{"request_id"},
+			},
+		},
+	}
+}

--- a/internal/server/policy/policy.go
+++ b/internal/server/policy/policy.go
@@ -7,6 +7,7 @@ package policy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -130,6 +131,9 @@ func (e *Engine) EvalTimeoutSeconds(ctx context.Context, identity *auth.Identity
 		return int64(n), nil
 	case int64:
 		return n, nil
+	case json.Number:
+		i, _ := n.Int64()
+		return i, nil
 	case nil:
 		return 0, nil
 	}

--- a/internal/server/policy/policy.go
+++ b/internal/server/policy/policy.go
@@ -22,10 +22,12 @@ import (
 type Engine struct {
 	store *store.Store
 
-	mu                sync.RWMutex
-	eligibilityQuery  *rego.PreparedEvalQuery
-	approvalQuery     *rego.PreparedEvalQuery
-	approvalTierQuery *rego.PreparedEvalQuery
+	mu                   sync.RWMutex
+	eligibilityQuery     *rego.PreparedEvalQuery
+	approvalQuery        *rego.PreparedEvalQuery
+	approvalTierQuery    *rego.PreparedEvalQuery
+	timeoutSecondsQuery  *rego.PreparedEvalQuery // data.jitsudo.approval.timeout_seconds
+	timeoutActionQuery   *rego.PreparedEvalQuery // data.jitsudo.approval.timeout_action
 }
 
 // NewEngine returns an Engine. Call Reload before first use.
@@ -48,11 +50,21 @@ func (e *Engine) Reload(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("policy: reload approver_tier: %w", err)
 	}
+	tsq, err := e.buildQuery(ctx, store.PolicyTypeApproval, "data.jitsudo.approval.timeout_seconds")
+	if err != nil {
+		return fmt.Errorf("policy: reload timeout_seconds: %w", err)
+	}
+	taq, err := e.buildQuery(ctx, store.PolicyTypeApproval, "data.jitsudo.approval.timeout_action")
+	if err != nil {
+		return fmt.Errorf("policy: reload timeout_action: %w", err)
+	}
 
 	e.mu.Lock()
 	e.eligibilityQuery = eliq
 	e.approvalQuery = appq
 	e.approvalTierQuery = tierq
+	e.timeoutSecondsQuery = tsq
+	e.timeoutActionQuery = taq
 	e.mu.Unlock()
 
 	log.Info().Msg("policy engine reloaded")
@@ -99,6 +111,55 @@ func (e *Engine) EvalApproval(ctx context.Context, approver *auth.Identity, req 
 	return e.eval(ctx, q, buildInput(approver, req.Provider, req.Role, req.ResourceScope, req.DurationSeconds, tier))
 }
 
+// EvalTimeoutSeconds evaluates data.jitsudo.approval.timeout_seconds for a request.
+// Returns 0 if the rule is not defined (meaning no timeout applies).
+func (e *Engine) EvalTimeoutSeconds(ctx context.Context, identity *auth.Identity, provider, role, resourceScope string, durationSeconds int64) (int64, error) {
+	e.mu.RLock()
+	q := e.timeoutSecondsQuery
+	e.mu.RUnlock()
+	if q == nil {
+		return 0, nil
+	}
+	trustTier := e.principalTrustTier(ctx, identity.Email)
+	v, err := e.evalScalar(ctx, q, buildInput(identity, provider, role, resourceScope, durationSeconds, trustTier))
+	if err != nil {
+		return 0, err
+	}
+	switch n := v.(type) {
+	case float64:
+		return int64(n), nil
+	case int64:
+		return n, nil
+	case nil:
+		return 0, nil
+	}
+	return 0, nil
+}
+
+// EvalTimeoutAction evaluates data.jitsudo.approval.timeout_action for a request.
+// Returns "deny" if the rule is not defined (safe default).
+// Valid values: "deny", "auto_approve", "escalate".
+func (e *Engine) EvalTimeoutAction(ctx context.Context, identity *auth.Identity, provider, role, resourceScope string, durationSeconds int64) (string, error) {
+	e.mu.RLock()
+	q := e.timeoutActionQuery
+	e.mu.RUnlock()
+	if q == nil {
+		return "deny", nil
+	}
+	trustTier := e.principalTrustTier(ctx, identity.Email)
+	v, err := e.evalScalar(ctx, q, buildInput(identity, provider, role, resourceScope, durationSeconds, trustTier))
+	if err != nil {
+		return "deny", err
+	}
+	action, _ := v.(string)
+	switch action {
+	case "deny", "auto_approve", "escalate":
+		return action, nil
+	default:
+		return "deny", nil
+	}
+}
+
 // EvalRaw evaluates the given policy type against a pre-built OPA input map.
 // This is used by the EvalPolicy RPC for dry-run evaluation.
 func (e *Engine) EvalRaw(ctx context.Context, ptype store.PolicyType, input map[string]any) (bool, string, error) {
@@ -138,6 +199,8 @@ func (e *Engine) CompileCheck(ctx context.Context, proposed *store.PolicyRow) er
 		queries = []string{
 			"data.jitsudo.approval.allow",
 			"data.jitsudo.approval.approver_tier",
+			"data.jitsudo.approval.timeout_seconds",
+			"data.jitsudo.approval.timeout_action",
 		}
 	}
 	for _, q := range queries {
@@ -167,6 +230,8 @@ func (e *Engine) CompileCheckWithout(ctx context.Context, removedID string, ptyp
 		queries = []string{
 			"data.jitsudo.approval.allow",
 			"data.jitsudo.approval.approver_tier",
+			"data.jitsudo.approval.timeout_seconds",
+			"data.jitsudo.approval.timeout_action",
 		}
 	}
 	for _, q := range queries {
@@ -272,8 +337,23 @@ func (e *Engine) evalTier(ctx context.Context, q *rego.PreparedEvalQuery, input 
 	}
 }
 
+// evalScalar runs a prepared query and returns the raw expression value (any type).
+// Returns nil if the rule is undefined. Used for timeout_seconds and timeout_action.
+func (e *Engine) evalScalar(ctx context.Context, q *rego.PreparedEvalQuery, input map[string]any) (any, error) {
+	results, err := q.Eval(ctx, rego.EvalInput(input))
+	if err != nil {
+		return nil, fmt.Errorf("policy: eval scalar: %w", err)
+	}
+	if len(results) == 0 || len(results[0].Expressions) == 0 {
+		return nil, nil
+	}
+	return results[0].Expressions[0].Value, nil
+}
+
 // buildInput constructs the OPA input document.
 // trustTier is the principal's current trust tier (0–4) from the principals table.
+// identity.PrincipalType is included as input.context.principal_type so that Rego
+// policies can differentiate between human CLI requests and MCP agent requests.
 func buildInput(identity *auth.Identity, provider, role, resourceScope string, durationSeconds int64, trustTier int) map[string]any {
 	return map[string]any{
 		"user": map[string]any{
@@ -288,7 +368,8 @@ func buildInput(identity *auth.Identity, provider, role, resourceScope string, d
 			"duration_seconds": durationSeconds,
 		},
 		"context": map[string]any{
-			"trust_tier": trustTier,
+			"trust_tier":     trustTier,
+			"principal_type": string(identity.PrincipalType),
 		},
 	}
 }

--- a/internal/server/policy/policy.go
+++ b/internal/server/policy/policy.go
@@ -23,12 +23,12 @@ import (
 type Engine struct {
 	store *store.Store
 
-	mu                   sync.RWMutex
-	eligibilityQuery     *rego.PreparedEvalQuery
-	approvalQuery        *rego.PreparedEvalQuery
-	approvalTierQuery    *rego.PreparedEvalQuery
-	timeoutSecondsQuery  *rego.PreparedEvalQuery // data.jitsudo.approval.timeout_seconds
-	timeoutActionQuery   *rego.PreparedEvalQuery // data.jitsudo.approval.timeout_action
+	mu                  sync.RWMutex
+	eligibilityQuery    *rego.PreparedEvalQuery
+	approvalQuery       *rego.PreparedEvalQuery
+	approvalTierQuery   *rego.PreparedEvalQuery
+	timeoutSecondsQuery *rego.PreparedEvalQuery // data.jitsudo.approval.timeout_seconds
+	timeoutActionQuery  *rego.PreparedEvalQuery // data.jitsudo.approval.timeout_action
 }
 
 // NewEngine returns an Engine. Call Reload before first use.

--- a/internal/server/policy/policy_test.go
+++ b/internal/server/policy/policy_test.go
@@ -14,6 +14,40 @@ import (
 	"github.com/jitsudo-dev/jitsudo/internal/store"
 )
 
+// newEngineWithTimeoutSecondsPolicy creates an Engine whose timeoutSecondsQuery
+// is compiled from the provided Rego string. No database is required.
+func newEngineWithTimeoutSecondsPolicy(t *testing.T, regoStr string) *Engine {
+	t.Helper()
+	opts := []func(*rego.Rego){
+		rego.Query("data.jitsudo.approval.timeout_seconds"),
+		rego.Module("test.rego", regoStr),
+	}
+	pq, err := rego.New(opts...).PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("PrepareForEval: %v", err)
+	}
+	e := &Engine{}
+	e.timeoutSecondsQuery = &pq
+	return e
+}
+
+// newEngineWithTimeoutActionPolicy creates an Engine whose timeoutActionQuery
+// is compiled from the provided Rego string. No database is required.
+func newEngineWithTimeoutActionPolicy(t *testing.T, regoStr string) *Engine {
+	t.Helper()
+	opts := []func(*rego.Rego){
+		rego.Query("data.jitsudo.approval.timeout_action"),
+		rego.Module("test.rego", regoStr),
+	}
+	pq, err := rego.New(opts...).PrepareForEval(context.Background())
+	if err != nil {
+		t.Fatalf("PrepareForEval: %v", err)
+	}
+	e := &Engine{}
+	e.timeoutActionQuery = &pq
+	return e
+}
+
 // newEngineWithTierPolicy creates an Engine whose approvalTierQuery is compiled
 // from the provided Rego string. No database is required.
 func newEngineWithTierPolicy(t *testing.T, regoStr string) *Engine {
@@ -428,5 +462,129 @@ allow if {
 	}
 	if allowed {
 		t.Error("expected denied for wrong group, got allowed")
+	}
+}
+
+// ── EvalTimeoutSeconds ────────────────────────────────────────────────────────
+
+func TestEvalTimeoutSeconds_NilQuery(t *testing.T) {
+	e := &Engine{} // timeoutSecondsQuery is nil
+	secs, err := e.EvalTimeoutSeconds(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutSeconds: %v", err)
+	}
+	if secs != 0 {
+		t.Errorf("secs = %d, want 0 for nil query", secs)
+	}
+}
+
+func TestEvalTimeoutSeconds_ReturnsValue(t *testing.T) {
+	e := newEngineWithTimeoutSecondsPolicy(t, `
+package jitsudo.approval
+import rego.v1
+
+timeout_seconds := 300
+`)
+	secs, err := e.EvalTimeoutSeconds(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutSeconds: %v", err)
+	}
+	if secs != 300 {
+		t.Errorf("secs = %d, want 300", secs)
+	}
+}
+
+func TestEvalTimeoutSeconds_RuleNotDefined(t *testing.T) {
+	// Policy has no timeout_seconds rule — the query result is undefined.
+	e := newEngineWithTimeoutSecondsPolicy(t, `
+package jitsudo.approval
+import rego.v1
+
+default approver_tier := "human"
+`)
+	secs, err := e.EvalTimeoutSeconds(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutSeconds: %v", err)
+	}
+	if secs != 0 {
+		t.Errorf("secs = %d, want 0 when rule is not defined", secs)
+	}
+}
+
+// ── EvalTimeoutAction ─────────────────────────────────────────────────────────
+
+func TestEvalTimeoutAction_NilQuery(t *testing.T) {
+	e := &Engine{} // timeoutActionQuery is nil
+	action, err := e.EvalTimeoutAction(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutAction: %v", err)
+	}
+	if action != "deny" {
+		t.Errorf("action = %q, want deny for nil query", action)
+	}
+}
+
+func TestEvalTimeoutAction_Deny(t *testing.T) {
+	e := newEngineWithTimeoutActionPolicy(t, `
+package jitsudo.approval
+import rego.v1
+
+timeout_action := "deny"
+`)
+	action, err := e.EvalTimeoutAction(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutAction: %v", err)
+	}
+	if action != "deny" {
+		t.Errorf("action = %q, want deny", action)
+	}
+}
+
+func TestEvalTimeoutAction_AutoApprove(t *testing.T) {
+	e := newEngineWithTimeoutActionPolicy(t, `
+package jitsudo.approval
+import rego.v1
+
+timeout_action := "auto_approve"
+`)
+	action, err := e.EvalTimeoutAction(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutAction: %v", err)
+	}
+	if action != "auto_approve" {
+		t.Errorf("action = %q, want auto_approve", action)
+	}
+}
+
+func TestEvalTimeoutAction_Escalate(t *testing.T) {
+	e := newEngineWithTimeoutActionPolicy(t, `
+package jitsudo.approval
+import rego.v1
+
+timeout_action := "escalate"
+`)
+	action, err := e.EvalTimeoutAction(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutAction: %v", err)
+	}
+	if action != "escalate" {
+		t.Errorf("action = %q, want escalate", action)
+	}
+}
+
+func TestEvalTimeoutAction_UnrecognizedValue(t *testing.T) {
+	e := newEngineWithTimeoutActionPolicy(t, `
+package jitsudo.approval
+import rego.v1
+
+timeout_action := "do_something_custom"
+`)
+	action, err := e.EvalTimeoutAction(context.Background(), testIdentity(), "aws", "admin", "123456789012", 3600)
+	if err != nil {
+		t.Fatalf("EvalTimeoutAction: %v", err)
+	}
+	// Unrecognized values must fall back to the safe default.
+	if action != "deny" {
+		t.Errorf("action = %q, want deny for unrecognized value", action)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jitsudo-dev/jitsudo/internal/server/audit"
 	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
 	"github.com/jitsudo-dev/jitsudo/internal/server/mcp"
+	"github.com/jitsudo-dev/jitsudo/internal/server/mcpagent"
 	"github.com/jitsudo-dev/jitsudo/internal/server/notifications"
 	"github.com/jitsudo-dev/jitsudo/internal/server/policy"
 	"github.com/jitsudo-dev/jitsudo/internal/server/workflow"
@@ -66,6 +67,12 @@ type Config struct {
 	// MCPAgentIdentity is the name recorded in the audit log for MCP decisions.
 	// Defaults to "mcp-agent" if empty.
 	MCPAgentIdentity string
+
+	// MCPAgentAddr is the listen address for the MCP agent-requestor server.
+	// When non-empty a second http.Server is started on this address exposing
+	// POST /mcp/agent/messages and GET /mcp/agent/sse.
+	// Default ":8081"; set to "" to disable.
+	MCPAgentAddr string
 
 	// AdminEmails lists email addresses that are granted admin privileges
 	// regardless of group membership. Useful when the OIDC provider does not
@@ -133,8 +140,20 @@ func (s *Server) Start(ctx context.Context) error {
 		return fmt.Errorf("server: policy engine reload: %w", err)
 	}
 
+	// ── MCP agent broker (must be built before the dispatcher) ───────────────
+	// The broker is appended to the notifier list so it receives every workflow
+	// event. It must exist before NewDispatcher is called because the dispatcher
+	// captures the notifier list at construction time.
+	var agentBroker *mcpagent.Broker
+	if s.cfg.MCPAgentAddr != "" {
+		agentBroker = mcpagent.NewBroker(s.store)
+	}
+
 	// ── Notification dispatcher ───────────────────────────────────────────────
 	var notifiers []notifications.Notifier
+	if agentBroker != nil {
+		notifiers = append(notifiers, agentBroker)
+	}
 	if cfg := s.cfg.Notifications.Slack; cfg != nil && cfg.WebhookURL != "" {
 		notifiers = append(notifiers, notifications.NewSlackNotifier(*cfg))
 	}
@@ -262,8 +281,28 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 
+	// ── MCP agent HTTP server ─────────────────────────────────────────────────
+	var mcpAgentHTTP *http.Server
+	mcpAgentErrC := make(chan error, 1)
+	if s.cfg.MCPAgentAddr != "" {
+		agentSrv := mcpagent.New(workflowEngine, s.store, verifier, agentBroker)
+		mcpAgentHTTP = &http.Server{
+			Addr:    s.cfg.MCPAgentAddr,
+			Handler: agentSrv.Handler(),
+		}
+		go func() {
+			log.Info().Str("addr", s.cfg.MCPAgentAddr).Msg("jitsudod MCP agent server starting")
+			if err := mcpAgentHTTP.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				mcpAgentErrC <- fmt.Errorf("MCP agent server error: %w", err)
+			}
+		}()
+	}
+
 	// ── Expiry sweeper ────────────────────────────────────────────────────────
 	go workflowEngine.RunExpirySweeper(ctx, 30*time.Second)
+
+	// ── Pending timeout sweeper ───────────────────────────────────────────────
+	go workflowEngine.RunPendingTimeoutSweeper(ctx, 30*time.Second)
 
 	// ── Periodic policy sync ──────────────────────────────────────────────────
 	// Each instance independently re-reads policies from the database every 30s,
@@ -292,10 +331,15 @@ func (s *Server) Start(ctx context.Context) error {
 		s.grpcServer.GracefulStop()
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer shutdownCancel()
+		if mcpAgentHTTP != nil {
+			_ = mcpAgentHTTP.Shutdown(shutdownCtx)
+		}
 		return s.httpServer.Shutdown(shutdownCtx)
 	case err := <-grpcErrC:
 		return err
 	case err := <-httpErrC:
+		return err
+	case err := <-mcpAgentErrC:
 		return err
 	}
 }

--- a/internal/server/workflow/workflow.go
+++ b/internal/server/workflow/workflow.go
@@ -40,6 +40,10 @@ type engineStore interface {
 	SetApproverTier(ctx context.Context, id string, tier string) error
 	ListActiveExpired(ctx context.Context) ([]*store.RequestRow, error)
 	TryAcquireSweepLock(ctx context.Context) (bool, func(), error)
+	// MCP agent requestor surface
+	ListActiveGrantsByIdentity(ctx context.Context, identity string) ([]*store.RequestRow, error)
+	ListPendingTimedOut(ctx context.Context) ([]*store.RequestRow, error)
+	TryAcquirePendingTimeoutLock(ctx context.Context) (bool, func(), error)
 }
 
 // auditAppender is the subset of *audit.Logger used by the Engine.
@@ -820,5 +824,234 @@ func (e *Engine) sweepExpired(ctx context.Context) {
 		})
 
 		log.Info().Str("request_id", req.ID).Msg("grant expired")
+	}
+}
+
+// MCPRequestInput carries the parameters from the MCP agent's request_access tool call.
+// Action maps to the role column (e.g. "s3:GetObject"); Resource maps to resource_scope
+// (e.g. "arn:aws:s3:::my-bucket/*"). Additional MCP-specific fields are stored in Metadata.
+type MCPRequestInput struct {
+	Action          string
+	Resource        string
+	DurationSeconds int64
+	Reason          string
+	TicketRef       string
+}
+
+// inferProviderFromResource returns the provider name inferred from the resource identifier.
+// Returns "mock" for MVP; TODO: route by ARN prefix (aws, gcp, azure) in a future milestone.
+func inferProviderFromResource(_ string) string {
+	return "mock" // TODO: route by ARN prefix
+}
+
+// CreateMCPRequest creates a PENDING elevation request from the MCP agent requestor surface.
+// It maps action→role and resource→resource_scope using the unified request model, stores
+// additional MCP fields in the metadata JSONB column, and sets pending_timeout_at /
+// pending_timeout_action from policy evaluation.
+func (e *Engine) CreateMCPRequest(ctx context.Context, identity *auth.Identity, input MCPRequestInput) (*store.RequestRow, error) {
+	provider := inferProviderFromResource(input.Resource)
+
+	p := e.registry.Get(provider)
+	if p == nil {
+		return nil, fmt.Errorf("workflow: unknown provider %q (inferred from resource)", provider)
+	}
+
+	_ = e.store.UpsertPrincipalLastSeen(ctx, identity.Email)
+
+	// Build a wrapper so we can call the existing policy evaluation methods.
+	policyInput := &jitsudov1alpha1.CreateRequestInput{
+		Provider:        provider,
+		Role:            input.Action,
+		ResourceScope:   input.Resource,
+		DurationSeconds: input.DurationSeconds,
+	}
+
+	allowed, reason, err := e.policy.EvalEligibility(ctx, identity, policyInput)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: mcp eligibility eval: %w", err)
+	}
+	if !allowed {
+		if reason == "" {
+			reason = "policy denied the request"
+		}
+		return nil, fmt.Errorf("workflow: not eligible: %s", reason)
+	}
+
+	tier, err := e.policy.EvalApprovalTier(ctx, identity, policyInput)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: mcp approval tier eval: %w", err)
+	}
+
+	timeoutSecs, err := e.policy.EvalTimeoutSeconds(ctx, identity, provider, input.Action, input.Resource, input.DurationSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: mcp timeout_seconds eval: %w", err)
+	}
+	timeoutAction, err := e.policy.EvalTimeoutAction(ctx, identity, provider, input.Action, input.Resource, input.DurationSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("workflow: mcp timeout_action eval: %w", err)
+	}
+
+	now := time.Now().UTC()
+	meta := map[string]string{"action": input.Action}
+	if input.TicketRef != "" {
+		meta["ticket_ref"] = input.TicketRef
+	}
+
+	req := &store.RequestRow{
+		ID:                "req_" + ulid.Make().String(),
+		State:             store.StatePending,
+		RequesterIdentity: identity.Email,
+		Provider:          provider,
+		Role:              input.Action,
+		ResourceScope:     input.Resource,
+		DurationSeconds:   input.DurationSeconds,
+		Reason:            input.Reason,
+		BreakGlass:        false,
+		Metadata:          meta,
+		ApproverTier:      tier,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if timeoutSecs > 0 {
+		t := now.Add(time.Duration(timeoutSecs) * time.Second)
+		req.PendingTimeoutAt = &t
+		req.PendingTimeoutAction = timeoutAction
+	}
+
+	if err := e.store.CreateRequest(ctx, req); err != nil {
+		return nil, fmt.Errorf("workflow: mcp create request: %w", err)
+	}
+
+	e.appendAudit(ctx, audit.Entry{
+		ActorIdentity: identity.Email,
+		Action:        audit.ActionRequestCreated,
+		RequestID:     req.ID,
+		Provider:      req.Provider,
+		ResourceScope: req.ResourceScope,
+		Outcome:       audit.OutcomeSuccess,
+		DetailsJSON:   `{"requestor_surface":"mcp","principal":{"type":"agent"}}`,
+	})
+
+	if tier == "auto" {
+		return e.autoApproveRequest(ctx, identity, req, p)
+	}
+
+	e.notifications.Notify(ctx, notifications.Event{
+		Type:      notifications.EventRequestCreated,
+		RequestID: req.ID,
+		Actor:     identity.Email,
+		Provider:  req.Provider,
+		Role:      req.Role,
+		Scope:     req.ResourceScope,
+		Reason:    req.Reason,
+	})
+
+	return req, nil
+}
+
+// RunPendingTimeoutSweeper runs in a goroutine and handles PENDING requests whose
+// pending_timeout_at deadline has passed. Mirrors RunExpirySweeper.
+// It exits when ctx is cancelled.
+func (e *Engine) RunPendingTimeoutSweeper(ctx context.Context, interval time.Duration) {
+	log.Info().Dur("interval", interval).Msg("pending timeout sweeper started")
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.sweepPendingTimedOut(ctx)
+		}
+	}
+}
+
+func (e *Engine) sweepPendingTimedOut(ctx context.Context) {
+	acquired, release, err := e.store.TryAcquirePendingTimeoutLock(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("pending timeout sweeper: advisory lock error")
+		return
+	}
+	if !acquired {
+		return
+	}
+	defer release()
+
+	timedOut, err := e.store.ListPendingTimedOut(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("pending timeout sweeper: list failed")
+		return
+	}
+
+	for _, req := range timedOut {
+		switch req.PendingTimeoutAction {
+		case "auto_approve":
+			p := e.registry.Get(req.Provider)
+			if p == nil {
+				log.Error().Str("request_id", req.ID).Str("provider", req.Provider).
+					Msg("pending timeout sweeper: provider not found for auto_approve")
+				continue
+			}
+			syntheticIdentity := &auth.Identity{Email: req.RequesterIdentity}
+			if _, err := e.autoApproveRequest(ctx, syntheticIdentity, req, p); err != nil {
+				log.Error().Err(err).Str("request_id", req.ID).Msg("pending timeout sweeper: auto_approve failed")
+			} else {
+				log.Info().Str("request_id", req.ID).Msg("pending timeout: auto-approved")
+			}
+
+		case "escalate":
+			e.appendAudit(ctx, audit.Entry{
+				ActorIdentity: "system",
+				Action:        audit.ActionRequestAIEscalated,
+				RequestID:     req.ID,
+				Provider:      req.Provider,
+				ResourceScope: req.ResourceScope,
+				Outcome:       audit.OutcomeSuccess,
+				DetailsJSON:   `{"reason":"pending_timeout_escalate"}`,
+			})
+			if err := e.store.SetApproverTier(ctx, req.ID, "human"); err != nil {
+				log.Error().Err(err).Str("request_id", req.ID).Msg("pending timeout sweeper: escalate set tier failed")
+				continue
+			}
+			e.notifications.Notify(ctx, notifications.Event{
+				Type:      notifications.EventAIEscalated,
+				RequestID: req.ID,
+				Actor:     "system",
+				Provider:  req.Provider,
+				Role:      req.Role,
+				Scope:     req.ResourceScope,
+				Reason:    "pending_timeout_escalate",
+			})
+			log.Info().Str("request_id", req.ID).Msg("pending timeout: escalated to human")
+
+		default: // "deny" or any unrecognised value — safe default is deny
+			e.appendAudit(ctx, audit.Entry{
+				ActorIdentity: "system",
+				Action:        audit.ActionRequestDenied,
+				RequestID:     req.ID,
+				Provider:      req.Provider,
+				ResourceScope: req.ResourceScope,
+				Outcome:       audit.OutcomeSuccess,
+				DetailsJSON:   `{"reason":"pending_timeout_deny"}`,
+			})
+			if _, err := e.store.TransitionRequest(ctx, req.ID,
+				store.StatePending, store.StateRejected,
+				store.RequestUpdate{ApproverComment: "Denied by pending timeout policy"},
+			); err != nil {
+				log.Error().Err(err).Str("request_id", req.ID).Msg("pending timeout sweeper: deny transition failed")
+				continue
+			}
+			e.notifications.Notify(ctx, notifications.Event{
+				Type:      notifications.EventDenied,
+				RequestID: req.ID,
+				Actor:     "system",
+				Provider:  req.Provider,
+				Role:      req.Role,
+				Scope:     req.ResourceScope,
+				Reason:    "pending timeout expired",
+			})
+			log.Info().Str("request_id", req.ID).Msg("pending timeout: denied")
+		}
 	}
 }

--- a/internal/server/workflow/workflow.go
+++ b/internal/server/workflow/workflow.go
@@ -25,7 +25,6 @@ import (
 	"github.com/jitsudo-dev/jitsudo/internal/server/audit"
 	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
 	"github.com/jitsudo-dev/jitsudo/internal/server/notifications"
-	"github.com/jitsudo-dev/jitsudo/internal/server/policy"
 	"github.com/jitsudo-dev/jitsudo/internal/store"
 )
 
@@ -49,11 +48,21 @@ type auditAppender interface {
 	Append(ctx context.Context, e audit.Entry) error
 }
 
+// policyEvaluator is the subset of *policy.Engine used by the Engine.
+// Extracted as an interface so unit tests can substitute a stub without OPA.
+type policyEvaluator interface {
+	EvalEligibility(ctx context.Context, identity *auth.Identity, input *jitsudov1alpha1.CreateRequestInput) (bool, string, error)
+	EvalApprovalTier(ctx context.Context, identity *auth.Identity, input *jitsudov1alpha1.CreateRequestInput) (string, error)
+	EvalApproval(ctx context.Context, approver *auth.Identity, req *store.RequestRow) (bool, string, error)
+	EvalTimeoutSeconds(ctx context.Context, identity *auth.Identity, provider, role, resourceScope string, durationSeconds int64) (int64, error)
+	EvalTimeoutAction(ctx context.Context, identity *auth.Identity, provider, role, resourceScope string, durationSeconds int64) (string, error)
+}
+
 // Engine drives elevation request lifecycle transitions.
 type Engine struct {
 	store         engineStore
 	audit         auditAppender
-	policy        *policy.Engine
+	policy        policyEvaluator
 	registry      *providers.Registry
 	notifications *notifications.Dispatcher
 }
@@ -61,7 +70,7 @@ type Engine struct {
 // NewEngine wires together the store, audit logger, policy engine, provider
 // registry, and optional notification dispatcher.
 // Passing nil for dispatcher disables notifications.
-func NewEngine(s engineStore, a auditAppender, p *policy.Engine, r *providers.Registry, n *notifications.Dispatcher) *Engine {
+func NewEngine(s engineStore, a auditAppender, p policyEvaluator, r *providers.Registry, n *notifications.Dispatcher) *Engine {
 	return &Engine{store: s, audit: a, policy: p, registry: r, notifications: n}
 }
 

--- a/internal/server/workflow/workflow.go
+++ b/internal/server/workflow/workflow.go
@@ -836,8 +836,6 @@ type MCPRequestInput struct {
 	TicketRef       string
 }
 
-// inferProviderFromResource returns the provider name inferred from the resource identifier.
-// Returns "mock" for MVP; TODO: route by ARN prefix (aws, gcp, azure) in a future milestone.
 func inferProviderFromResource(_ string) string {
 	return "mock" // TODO: route by ARN prefix
 }

--- a/internal/server/workflow/workflow.go
+++ b/internal/server/workflow/workflow.go
@@ -40,8 +40,6 @@ type engineStore interface {
 	SetApproverTier(ctx context.Context, id string, tier string) error
 	ListActiveExpired(ctx context.Context) ([]*store.RequestRow, error)
 	TryAcquireSweepLock(ctx context.Context) (bool, func(), error)
-	// MCP agent requestor surface
-	ListActiveGrantsByIdentity(ctx context.Context, identity string) ([]*store.RequestRow, error)
 	ListPendingTimedOut(ctx context.Context) ([]*store.RequestRow, error)
 	TryAcquirePendingTimeoutLock(ctx context.Context) (bool, func(), error)
 }

--- a/internal/server/workflow/workflow_test.go
+++ b/internal/server/workflow/workflow_test.go
@@ -135,10 +135,6 @@ func (s *stubStore) TryAcquireSweepLock(_ context.Context) (bool, func(), error)
 	return s.sweepLockAcquired, func() {}, nil
 }
 
-func (s *stubStore) ListActiveGrantsByIdentity(_ context.Context, _ string) ([]*store.RequestRow, error) {
-	return nil, nil
-}
-
 func (s *stubStore) ListPendingTimedOut(_ context.Context) ([]*store.RequestRow, error) {
 	return nil, nil
 }

--- a/internal/server/workflow/workflow_test.go
+++ b/internal/server/workflow/workflow_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	jitsudov1alpha1 "github.com/jitsudo-dev/jitsudo/internal/gen/proto/go/jitsudo/v1alpha1"
 	"github.com/jitsudo-dev/jitsudo/internal/providers"
 	"github.com/jitsudo-dev/jitsudo/internal/providers/mock"
 	"github.com/jitsudo-dev/jitsudo/internal/server/audit"
+	"github.com/jitsudo-dev/jitsudo/internal/server/auth"
 	"github.com/jitsudo-dev/jitsudo/internal/store"
 )
 
@@ -36,12 +39,21 @@ type stubStore struct {
 	activeExpiredRows []*store.RequestRow
 	// listExpiredCalled is set true whenever ListActiveExpired is invoked.
 	listExpiredCalled bool
+
+	// Advisory lock control for sweepPendingTimedOut tests.
+	pendingLockAcquired bool  // default true
+	pendingLockErr      error // non-nil simulates a lock acquisition failure
+
+	// Rows returned by ListPendingTimedOut. Default nil (none).
+	pendingTimedOutRows  []*store.RequestRow
+	pendingTimedOutCalled bool
 }
 
 func newStubStore(rows ...*store.RequestRow) *stubStore {
 	s := &stubStore{
-		rows:              make(map[string]*store.RequestRow),
-		sweepLockAcquired: true, // default: this instance wins the lock
+		rows:                make(map[string]*store.RequestRow),
+		sweepLockAcquired:  true, // default: this instance wins the expiry lock
+		pendingLockAcquired: true, // default: this instance wins the pending timeout lock
 	}
 	for _, r := range rows {
 		cp := *r
@@ -136,11 +148,17 @@ func (s *stubStore) TryAcquireSweepLock(_ context.Context) (bool, func(), error)
 }
 
 func (s *stubStore) ListPendingTimedOut(_ context.Context) ([]*store.RequestRow, error) {
-	return nil, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingTimedOutCalled = true
+	return s.pendingTimedOutRows, nil
 }
 
 func (s *stubStore) TryAcquirePendingTimeoutLock(_ context.Context) (bool, func(), error) {
-	return true, func() {}, nil
+	if s.pendingLockErr != nil {
+		return false, func() {}, s.pendingLockErr
+	}
+	return s.pendingLockAcquired, func() {}, nil
 }
 
 // stubAudit records all Append calls for assertion.
@@ -175,6 +193,54 @@ func (a *stubAudit) findByAction(action string) (audit.Entry, bool) {
 		}
 	}
 	return audit.Entry{}, false
+}
+
+// ── stubPolicy ────────────────────────────────────────────────────────────────
+
+// stubPolicy is a configurable stub for the policyEvaluator interface.
+type stubPolicy struct {
+	eligibilityAllowed bool
+	eligibilityReason  string
+	eligibilityErr     error
+	tier               string // "auto", "human", "ai_review"
+	tierErr            error
+	approvalAllowed    bool
+	approvalErr        error
+	timeoutSecs        int64
+	timeoutSecsErr     error
+	timeoutAction      string
+	timeoutActionErr   error
+}
+
+func (p *stubPolicy) EvalEligibility(_ context.Context, _ *auth.Identity, _ *jitsudov1alpha1.CreateRequestInput) (bool, string, error) {
+	return p.eligibilityAllowed, p.eligibilityReason, p.eligibilityErr
+}
+
+func (p *stubPolicy) EvalApprovalTier(_ context.Context, _ *auth.Identity, _ *jitsudov1alpha1.CreateRequestInput) (string, error) {
+	return p.tier, p.tierErr
+}
+
+func (p *stubPolicy) EvalApproval(_ context.Context, _ *auth.Identity, _ *store.RequestRow) (bool, string, error) {
+	return p.approvalAllowed, "", p.approvalErr
+}
+
+func (p *stubPolicy) EvalTimeoutSeconds(_ context.Context, _ *auth.Identity, _, _, _ string, _ int64) (int64, error) {
+	return p.timeoutSecs, p.timeoutSecsErr
+}
+
+func (p *stubPolicy) EvalTimeoutAction(_ context.Context, _ *auth.Identity, _, _, _ string, _ int64) (string, error) {
+	return p.timeoutAction, p.timeoutActionErr
+}
+
+// allowPolicy returns a stubPolicy that allows eligibility with the given tier.
+func allowPolicy(tier string) *stubPolicy {
+	return &stubPolicy{eligibilityAllowed: true, tier: tier}
+}
+
+func newTestEngineWithPolicy(s engineStore, a auditAppender, p policyEvaluator) *Engine {
+	registry := providers.NewRegistry()
+	registry.Register(mock.New())
+	return NewEngine(s, a, p, registry, nil)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -513,5 +579,240 @@ func TestSweepExpired_LockError(t *testing.T) {
 	s.mu.Unlock()
 	if called {
 		t.Error("ListActiveExpired was called after a lock acquisition error")
+	}
+}
+
+// ── CreateMCPRequest ──────────────────────────────────────────────────────────
+
+func mcpIdentity() *auth.Identity {
+	return &auth.Identity{Email: "agent@example.com", Subject: "sub-agent"}
+}
+
+func mcpInput() MCPRequestInput {
+	return MCPRequestInput{
+		Action:          "s3:GetObject",
+		Resource:        "arn:aws:s3:::my-bucket/*",
+		DurationSeconds: 3600,
+		Reason:          "integration test",
+	}
+}
+
+func TestCreateMCPRequest_Pending(t *testing.T) {
+	s := newStubStore()
+	a := &stubAudit{}
+	pol := allowPolicy("human")
+	e := newTestEngineWithPolicy(s, a, pol)
+
+	req, err := e.CreateMCPRequest(context.Background(), mcpIdentity(), mcpInput())
+	if err != nil {
+		t.Fatalf("CreateMCPRequest: %v", err)
+	}
+	if req.State != store.StatePending {
+		t.Errorf("State = %q, want PENDING", req.State)
+	}
+	if req.PendingTimeoutAt != nil {
+		t.Error("expected nil PendingTimeoutAt when timeout_seconds=0")
+	}
+	if _, ok := a.findByAction(audit.ActionRequestCreated); !ok {
+		t.Errorf("audit missing %q; got %v", audit.ActionRequestCreated, a.actions())
+	}
+	if entry, ok := a.findByAction(audit.ActionRequestCreated); ok {
+		if !strings.Contains(entry.DetailsJSON, `"requestor_surface":"mcp"`) {
+			t.Errorf("audit DetailsJSON missing requestor_surface:mcp, got %q", entry.DetailsJSON)
+		}
+	}
+}
+
+func TestCreateMCPRequest_PendingWithTimeout(t *testing.T) {
+	s := newStubStore()
+	a := &stubAudit{}
+	pol := allowPolicy("human")
+	pol.timeoutSecs = 300
+	pol.timeoutAction = "deny"
+	e := newTestEngineWithPolicy(s, a, pol)
+
+	req, err := e.CreateMCPRequest(context.Background(), mcpIdentity(), mcpInput())
+	if err != nil {
+		t.Fatalf("CreateMCPRequest: %v", err)
+	}
+	if req.PendingTimeoutAt == nil {
+		t.Error("expected non-nil PendingTimeoutAt when timeout_seconds=300")
+	}
+	if req.PendingTimeoutAction != "deny" {
+		t.Errorf("PendingTimeoutAction = %q, want deny", req.PendingTimeoutAction)
+	}
+}
+
+func TestCreateMCPRequest_AutoApproved(t *testing.T) {
+	s := newStubStore()
+	a := &stubAudit{}
+	pol := allowPolicy("auto")
+	e := newTestEngineWithPolicy(s, a, pol)
+
+	req, err := e.CreateMCPRequest(context.Background(), mcpIdentity(), mcpInput())
+	if err != nil {
+		t.Fatalf("CreateMCPRequest: %v", err)
+	}
+	if req.State != store.StateActive {
+		t.Errorf("State = %q, want ACTIVE for auto tier", req.State)
+	}
+	if len(req.CredentialsJSON) == 0 {
+		t.Error("expected credentials after auto-approve")
+	}
+	actions := a.actions()
+	for _, want := range []string{audit.ActionRequestCreated, audit.ActionGrantIssued} {
+		found := false
+		for _, got := range actions {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("audit missing %q; got %v", want, actions)
+		}
+	}
+}
+
+func TestCreateMCPRequest_PolicyDenied(t *testing.T) {
+	s := newStubStore()
+	pol := &stubPolicy{eligibilityAllowed: false, eligibilityReason: "role not permitted"}
+	e := newTestEngineWithPolicy(s, &stubAudit{}, pol)
+
+	_, err := e.CreateMCPRequest(context.Background(), mcpIdentity(), mcpInput())
+	if err == nil {
+		t.Fatal("expected error for denied eligibility, got nil")
+	}
+	if !strings.Contains(err.Error(), "not eligible") {
+		t.Errorf("error = %q, want it to contain 'not eligible'", err.Error())
+	}
+}
+
+// ── sweepPendingTimedOut ──────────────────────────────────────────────────────
+
+func pendingTimeoutRow(id, action string) *store.RequestRow {
+	now := time.Now().UTC()
+	past := now.Add(-time.Minute)
+	return &store.RequestRow{
+		ID:                   id,
+		State:                store.StatePending,
+		RequesterIdentity:    "agent@example.com",
+		Provider:             "mock",
+		Role:                 "admin",
+		ResourceScope:        "test-scope",
+		DurationSeconds:      3600,
+		ApproverTier:         "human",
+		PendingTimeoutAt:     &past,
+		PendingTimeoutAction: action,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+}
+
+func TestSweepPendingTimedOut_LockNotAcquired(t *testing.T) {
+	row := pendingTimeoutRow("req_pt_001", "deny")
+	s := newStubStore(row)
+	s.pendingTimedOutRows = []*store.RequestRow{row}
+	s.pendingLockAcquired = false
+
+	e := newTestEngineWithPolicy(s, &stubAudit{}, allowPolicy("human"))
+	e.sweepPendingTimedOut(context.Background())
+
+	s.mu.Lock()
+	called := s.pendingTimedOutCalled
+	s.mu.Unlock()
+	if called {
+		t.Error("ListPendingTimedOut was called even though advisory lock was not acquired")
+	}
+	// Row must remain PENDING.
+	updated, _ := s.GetRequest(context.Background(), "req_pt_001")
+	if updated.State != store.StatePending {
+		t.Errorf("State = %q, want PENDING (sweep skipped)", updated.State)
+	}
+}
+
+func TestSweepPendingTimedOut_LockError(t *testing.T) {
+	s := newStubStore()
+	s.pendingLockErr = errors.New("db unavailable")
+
+	e := newTestEngineWithPolicy(s, &stubAudit{}, allowPolicy("human"))
+	// Must not panic.
+	e.sweepPendingTimedOut(context.Background())
+
+	s.mu.Lock()
+	called := s.pendingTimedOutCalled
+	s.mu.Unlock()
+	if called {
+		t.Error("ListPendingTimedOut was called after lock acquisition error")
+	}
+}
+
+func TestSweepPendingTimedOut_ActionDeny(t *testing.T) {
+	const reqID = "req_pt_deny"
+	row := pendingTimeoutRow(reqID, "deny")
+	s := newStubStore(row)
+	s.pendingTimedOutRows = []*store.RequestRow{row}
+
+	a := &stubAudit{}
+	e := newTestEngineWithPolicy(s, a, allowPolicy("human"))
+	e.sweepPendingTimedOut(context.Background())
+
+	updated, err := s.GetRequest(context.Background(), reqID)
+	if err != nil {
+		t.Fatalf("GetRequest: %v", err)
+	}
+	if updated.State != store.StateRejected {
+		t.Errorf("State = %q, want REJECTED", updated.State)
+	}
+	if _, ok := a.findByAction(audit.ActionRequestDenied); !ok {
+		t.Errorf("audit missing %q; got %v", audit.ActionRequestDenied, a.actions())
+	}
+}
+
+func TestSweepPendingTimedOut_ActionAutoApprove(t *testing.T) {
+	const reqID = "req_pt_auto"
+	row := pendingTimeoutRow(reqID, "auto_approve")
+	s := newStubStore(row)
+	s.pendingTimedOutRows = []*store.RequestRow{row}
+
+	a := &stubAudit{}
+	e := newTestEngineWithPolicy(s, a, allowPolicy("human"))
+	e.sweepPendingTimedOut(context.Background())
+
+	updated, err := s.GetRequest(context.Background(), reqID)
+	if err != nil {
+		t.Fatalf("GetRequest: %v", err)
+	}
+	if updated.State != store.StateActive {
+		t.Errorf("State = %q, want ACTIVE after auto_approve timeout", updated.State)
+	}
+	if _, ok := a.findByAction(audit.ActionGrantIssued); !ok {
+		t.Errorf("audit missing %q; got %v", audit.ActionGrantIssued, a.actions())
+	}
+}
+
+func TestSweepPendingTimedOut_ActionEscalate(t *testing.T) {
+	const reqID = "req_pt_esc"
+	row := pendingTimeoutRow(reqID, "escalate")
+	s := newStubStore(row)
+	s.pendingTimedOutRows = []*store.RequestRow{row}
+
+	a := &stubAudit{}
+	e := newTestEngineWithPolicy(s, a, allowPolicy("human"))
+	e.sweepPendingTimedOut(context.Background())
+
+	updated, err := s.GetRequest(context.Background(), reqID)
+	if err != nil {
+		t.Fatalf("GetRequest: %v", err)
+	}
+	// Row stays PENDING but tier is upgraded to "human".
+	if updated.State != store.StatePending {
+		t.Errorf("State = %q, want PENDING (escalate keeps request alive)", updated.State)
+	}
+	if updated.ApproverTier != "human" {
+		t.Errorf("ApproverTier = %q, want human", updated.ApproverTier)
+	}
+	if _, ok := a.findByAction(audit.ActionRequestAIEscalated); !ok {
+		t.Errorf("audit missing %q; got %v", audit.ActionRequestAIEscalated, a.actions())
 	}
 }

--- a/internal/server/workflow/workflow_test.go
+++ b/internal/server/workflow/workflow_test.go
@@ -45,14 +45,14 @@ type stubStore struct {
 	pendingLockErr      error // non-nil simulates a lock acquisition failure
 
 	// Rows returned by ListPendingTimedOut. Default nil (none).
-	pendingTimedOutRows  []*store.RequestRow
+	pendingTimedOutRows   []*store.RequestRow
 	pendingTimedOutCalled bool
 }
 
 func newStubStore(rows ...*store.RequestRow) *stubStore {
 	s := &stubStore{
 		rows:                make(map[string]*store.RequestRow),
-		sweepLockAcquired:  true, // default: this instance wins the expiry lock
+		sweepLockAcquired:   true, // default: this instance wins the expiry lock
 		pendingLockAcquired: true, // default: this instance wins the pending timeout lock
 	}
 	for _, r := range rows {

--- a/internal/server/workflow/workflow_test.go
+++ b/internal/server/workflow/workflow_test.go
@@ -135,6 +135,18 @@ func (s *stubStore) TryAcquireSweepLock(_ context.Context) (bool, func(), error)
 	return s.sweepLockAcquired, func() {}, nil
 }
 
+func (s *stubStore) ListActiveGrantsByIdentity(_ context.Context, _ string) ([]*store.RequestRow, error) {
+	return nil, nil
+}
+
+func (s *stubStore) ListPendingTimedOut(_ context.Context) ([]*store.RequestRow, error) {
+	return nil, nil
+}
+
+func (s *stubStore) TryAcquirePendingTimeoutLock(_ context.Context) (bool, func(), error) {
+	return true, func() {}, nil
+}
+
 // stubAudit records all Append calls for assertion.
 type stubAudit struct {
 	mu      sync.Mutex

--- a/internal/store/migrations/0006_mcp_agent.up.sql
+++ b/internal/store/migrations/0006_mcp_agent.up.sql
@@ -1,0 +1,22 @@
+-- Migration 0006: pending timeout support for elevation requests.
+--
+-- These columns are general request lifecycle fields — not MCP-specific.
+-- Any request type (human CLI or MCP agent) can have a policy-configured
+-- timeout that fires if no approval decision is made within timeout_seconds.
+--
+-- pending_timeout_at:     when the pending timeout sweeper should fire for this request.
+--                         NULL means no timeout applies (request waits indefinitely).
+-- pending_timeout_action: what the sweeper does when timeout fires:
+--                         'deny'         → transition PENDING → REJECTED
+--                         'auto_approve' → auto-approve as if tier=auto
+--                         'escalate'     → re-route to human approval queue
+
+ALTER TABLE elevation_requests
+    ADD COLUMN pending_timeout_at     TIMESTAMPTZ,
+    ADD COLUMN pending_timeout_action TEXT
+        CHECK (pending_timeout_action IN ('deny', 'auto_approve', 'escalate'));
+
+-- Partial index covering only rows where the sweeper has work to do.
+CREATE INDEX idx_elevation_requests_pending_timeout
+    ON elevation_requests(pending_timeout_at)
+    WHERE state = 'PENDING' AND pending_timeout_at IS NOT NULL;

--- a/internal/store/requests.go
+++ b/internal/store/requests.go
@@ -43,8 +43,13 @@ type RequestRow struct {
 	RevokeToken       string
 	CredentialsJSON   map[string]string // nil until ACTIVE
 	AIReasoningJSON   string            // populated by MCP approver for Tier 2 decisions
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	// PendingTimeoutAt and PendingTimeoutAction support policy-configured timeouts
+	// for pending requests. These are general lifecycle fields — not MCP-specific.
+	// NULL means no timeout applies (request waits indefinitely for approval).
+	PendingTimeoutAt     *time.Time
+	PendingTimeoutAction string // "deny" | "auto_approve" | "escalate" | ""
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 // RequestUpdate holds the fields that can be set during a state transition.
@@ -71,14 +76,22 @@ func (s *Store) CreateRequest(ctx context.Context, req *RequestRow) error {
 	if tier == "" {
 		tier = "human"
 	}
+	var timeoutAction *string
+	if req.PendingTimeoutAction != "" {
+		timeoutAction = &req.PendingTimeoutAction
+	}
 	_, err := s.db.Exec(ctx, `
 		INSERT INTO elevation_requests
 			(id, state, requester_identity, provider, role, resource_scope,
-			 duration_seconds, reason, break_glass, metadata, approver_tier, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+			 duration_seconds, reason, break_glass, metadata, approver_tier,
+			 pending_timeout_at, pending_timeout_action,
+			 created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
 		req.ID, string(req.State), req.RequesterIdentity, req.Provider,
 		req.Role, req.ResourceScope, req.DurationSeconds, req.Reason,
-		req.BreakGlass, metaJSON, tier, req.CreatedAt, req.UpdatedAt,
+		req.BreakGlass, metaJSON, tier,
+		req.PendingTimeoutAt, timeoutAction,
+		req.CreatedAt, req.UpdatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("store: CreateRequest: %w", err)
@@ -94,7 +107,9 @@ func (s *Store) GetRequest(ctx context.Context, id string) (*RequestRow, error) 
 		       COALESCE(approver_tier,'human'),
 		       COALESCE(approver_identity,''), COALESCE(approver_comment,''),
 		       expires_at, COALESCE(revoke_token,''), credentials_json,
-		       COALESCE(ai_reasoning_json,''), created_at, updated_at
+		       COALESCE(ai_reasoning_json,''),
+		       pending_timeout_at, COALESCE(pending_timeout_action,''),
+		       created_at, updated_at
 		FROM elevation_requests WHERE id = $1`, id)
 	return scanRequest(row)
 }
@@ -107,7 +122,9 @@ func (s *Store) ListRequests(ctx context.Context, f ListFilter) ([]*RequestRow, 
 		       COALESCE(approver_tier,'human'),
 		       COALESCE(approver_identity,''), COALESCE(approver_comment,''),
 		       expires_at, COALESCE(revoke_token,''), credentials_json,
-		       COALESCE(ai_reasoning_json,''), created_at, updated_at
+		       COALESCE(ai_reasoning_json,''),
+		       pending_timeout_at, COALESCE(pending_timeout_action,''),
+		       created_at, updated_at
 		FROM elevation_requests WHERE 1=1`
 	args := []any{}
 	n := 1
@@ -168,7 +185,9 @@ func (s *Store) ListPendingAIReview(ctx context.Context) ([]*RequestRow, error) 
 		       COALESCE(approver_tier,'human'),
 		       COALESCE(approver_identity,''), COALESCE(approver_comment,''),
 		       expires_at, COALESCE(revoke_token,''), credentials_json,
-		       COALESCE(ai_reasoning_json,''), created_at, updated_at
+		       COALESCE(ai_reasoning_json,''),
+		       pending_timeout_at, COALESCE(pending_timeout_action,''),
+		       created_at, updated_at
 		FROM elevation_requests
 		WHERE state = 'PENDING' AND approver_tier = 'ai_review'
 		ORDER BY created_at ASC LIMIT 100`)
@@ -197,7 +216,9 @@ func (s *Store) ListActiveExpired(ctx context.Context) ([]*RequestRow, error) {
 		       COALESCE(approver_tier,'human'),
 		       COALESCE(approver_identity,''), COALESCE(approver_comment,''),
 		       expires_at, COALESCE(revoke_token,''), credentials_json,
-		       COALESCE(ai_reasoning_json,''), created_at, updated_at
+		       COALESCE(ai_reasoning_json,''),
+		       pending_timeout_at, COALESCE(pending_timeout_action,''),
+		       created_at, updated_at
 		FROM elevation_requests
 		WHERE state = 'ACTIVE' AND expires_at <= NOW()`)
 	if err != nil {
@@ -280,9 +301,97 @@ func (s *Store) TransitionRequest(ctx context.Context, id string, fromState, toS
 	return s.GetRequest(ctx, id)
 }
 
+// ListActiveGrantsByIdentity returns all ACTIVE grants for a given requester identity
+// whose expiry is in the future (or have no expiry set). Used by the MCP agent
+// list_my_active_grants tool.
+func (s *Store) ListActiveGrantsByIdentity(ctx context.Context, identity string) ([]*RequestRow, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT id, state, requester_identity, provider, role, resource_scope,
+		       duration_seconds, reason, break_glass, metadata,
+		       COALESCE(approver_tier,'human'),
+		       COALESCE(approver_identity,''), COALESCE(approver_comment,''),
+		       expires_at, COALESCE(revoke_token,''), credentials_json,
+		       COALESCE(ai_reasoning_json,''),
+		       pending_timeout_at, COALESCE(pending_timeout_action,''),
+		       created_at, updated_at
+		FROM elevation_requests
+		WHERE state = 'ACTIVE'
+		  AND requester_identity = $1
+		  AND (expires_at IS NULL OR expires_at > NOW())
+		ORDER BY created_at DESC LIMIT 50`, identity)
+	if err != nil {
+		return nil, fmt.Errorf("store: ListActiveGrantsByIdentity: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*RequestRow
+	for rows.Next() {
+		r, err := scanRequest(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ListPendingTimedOut returns PENDING requests whose pending_timeout_at has passed.
+// Used by the pending timeout sweeper.
+func (s *Store) ListPendingTimedOut(ctx context.Context) ([]*RequestRow, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT id, state, requester_identity, provider, role, resource_scope,
+		       duration_seconds, reason, break_glass, metadata,
+		       COALESCE(approver_tier,'human'),
+		       COALESCE(approver_identity,''), COALESCE(approver_comment,''),
+		       expires_at, COALESCE(revoke_token,''), credentials_json,
+		       COALESCE(ai_reasoning_json,''),
+		       pending_timeout_at, COALESCE(pending_timeout_action,''),
+		       created_at, updated_at
+		FROM elevation_requests
+		WHERE state = 'PENDING'
+		  AND pending_timeout_at IS NOT NULL
+		  AND pending_timeout_at <= NOW()
+		ORDER BY pending_timeout_at ASC LIMIT 100`)
+	if err != nil {
+		return nil, fmt.Errorf("store: ListPendingTimedOut: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*RequestRow
+	for rows.Next() {
+		r, err := scanRequest(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// SetPendingTimeout sets the timeout deadline and action for a PENDING request.
+// Called by CreateMCPRequest (and potentially CreateRequest) when the policy
+// specifies a timeout_seconds value.
+func (s *Store) SetPendingTimeout(ctx context.Context, id string, timeoutAt time.Time, action string) error {
+	tag, err := s.db.Exec(ctx, `
+		UPDATE elevation_requests
+		SET pending_timeout_at = $2, pending_timeout_action = $3, updated_at = NOW()
+		WHERE id = $1 AND state = 'PENDING'`, id, timeoutAt, action)
+	if err != nil {
+		return fmt.Errorf("store: SetPendingTimeout: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // sweepLockKey is the PostgreSQL advisory lock key reserved for the expiry sweeper.
 // The value is fixed and must be identical across all jitsudod instances.
 const sweepLockKey = int64(7278657000) // "jitsudo\0" packed, avoids collision with ad-hoc keys
+
+// pendingTimeoutLockKey is the advisory lock key for the pending timeout sweeper.
+// Distinct from sweepLockKey so the two sweepers do not block each other.
+const pendingTimeoutLockKey = int64(7278657001)
 
 // TryAcquireSweepLock attempts a non-blocking session-level PostgreSQL advisory lock.
 // Only one jitsudod instance holds this lock at a time, ensuring the expiry sweeper
@@ -313,6 +422,30 @@ func (s *Store) TryAcquireSweepLock(ctx context.Context) (bool, func(), error) {
 	return true, release, nil
 }
 
+// TryAcquirePendingTimeoutLock is the same pattern as TryAcquireSweepLock but
+// uses pendingTimeoutLockKey so the pending timeout sweeper and the expiry
+// sweeper can run concurrently on different instances without blocking each other.
+func (s *Store) TryAcquirePendingTimeoutLock(ctx context.Context) (bool, func(), error) {
+	conn, err := s.db.Acquire(ctx)
+	if err != nil {
+		return false, func() {}, fmt.Errorf("store: pending timeout lock acquire conn: %w", err)
+	}
+	var acquired bool
+	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, pendingTimeoutLockKey).Scan(&acquired); err != nil {
+		conn.Release()
+		return false, func() {}, fmt.Errorf("store: pg_try_advisory_lock (pending timeout): %w", err)
+	}
+	if !acquired {
+		conn.Release()
+		return false, func() {}, nil
+	}
+	release := func() {
+		_, _ = conn.Exec(ctx, `SELECT pg_advisory_unlock($1)`, pendingTimeoutLockKey)
+		conn.Release()
+	}
+	return true, release, nil
+}
+
 // nullableJSON returns nil if the input is empty, otherwise the raw bytes.
 func nullableJSON(b []byte) interface{} {
 	if len(b) == 0 {
@@ -336,6 +469,7 @@ func scanRequest(row interface {
 		&r.ApproverIdentity, &r.ApproverComment,
 		&r.ExpiresAt, &r.RevokeToken, &credJSON,
 		&r.AIReasoningJSON,
+		&r.PendingTimeoutAt, &r.PendingTimeoutAction,
 		&r.CreatedAt, &r.UpdatedAt,
 	)
 	if err == pgx.ErrNoRows {

--- a/internal/store/requests.go
+++ b/internal/store/requests.go
@@ -302,8 +302,7 @@ func (s *Store) TransitionRequest(ctx context.Context, id string, fromState, toS
 }
 
 // ListActiveGrantsByIdentity returns all ACTIVE grants for a given requester identity
-// whose expiry is in the future (or have no expiry set). Used by the MCP agent
-// list_my_active_grants tool.
+// whose expiry is in the future (or have no expiry set).
 func (s *Store) ListActiveGrantsByIdentity(ctx context.Context, identity string) ([]*RequestRow, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT id, state, requester_identity, provider, role, resource_scope,
@@ -336,7 +335,6 @@ func (s *Store) ListActiveGrantsByIdentity(ctx context.Context, identity string)
 }
 
 // ListPendingTimedOut returns PENDING requests whose pending_timeout_at has passed.
-// Used by the pending timeout sweeper.
 func (s *Store) ListPendingTimedOut(ctx context.Context) ([]*RequestRow, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT id, state, requester_identity, provider, role, resource_scope,
@@ -369,8 +367,6 @@ func (s *Store) ListPendingTimedOut(ctx context.Context) ([]*RequestRow, error) 
 }
 
 // SetPendingTimeout sets the timeout deadline and action for a PENDING request.
-// Called by CreateMCPRequest (and potentially CreateRequest) when the policy
-// specifies a timeout_seconds value.
 func (s *Store) SetPendingTimeout(ctx context.Context, id string, timeoutAt time.Time, action string) error {
 	tag, err := s.db.Exec(ctx, `
 		UPDATE elevation_requests


### PR DESCRIPTION
## Summary

- Adds an MCP (Model Context Protocol) agent server with SSE and JSON-RPC HTTP handlers, OIDC bearer auth middleware, and an SSE-based resolution notification broker
- Exposes three MCP tools: `request_access`, `list_my_active_grants`, and `revoke_access`
- Extends the workflow engine with `CreateMCPRequest`, pending timeout sweep (`RunPendingTimeoutSweeper`), and a `policyEvaluator` interface
- Adds `principal_type` to OPA policy input and `timeout_seconds`/`timeout_action` policy queries; propagates `PrincipalType` through `Identity`
- Adds store migration 0006 for pending timeout columns; new store methods: `ListActiveGrantsByIdentity`, `ListPendingTimedOut`, `SetPendingTimeout`
- Wires a second HTTP listener (`MCPAgentAddr`) and pending sweeper into the main server; exposes MCP agent port 8081 in Helm

## Test plan

- [ ] Unit tests: `mcpagent`, workflow (`CreateMCPRequest`, `sweepPendingTimedOut`), policy timeout evaluation
- [ ] Integration: start server with `MCPAgentAddr` set, connect an MCP client via SSE, call `request_access` and verify grant flow end-to-end
- [ ] Verify `principal_type` appears in OPA decisions and `timeout_action` is enforced
- [ ] Run `make docker-up` and confirm port 8081 is reachable